### PR TITLE
`required` property is ignored outside of objects

### DIFF
--- a/test/test-enjoi.js
+++ b/test/test-enjoi.js
@@ -293,4 +293,25 @@ test('types', function (t) {
         });
     });
 
+
+    t.test('properties', function (t) {
+
+        t.test('required', function (t) {
+            t.plan(2);
+
+            var schema = enjoi({
+                'type': 'number',
+                'required': true
+            });
+
+            joi.validate(1, schema, function (error, value) {
+                t.ok(!error, 'no error.');
+            });
+
+            joi.validate(void 0, schema, function (error, value) {
+                t.ok(error, 'error.');
+            });
+        });
+    });
+
 });


### PR DESCRIPTION
A schema specifying the property is `required` passes validation even if it is `undefined`.

It is pretty clear from the code that `required` is walked only within `resolveproperties`, which is called only for objects.

This PR only adds a test demonstrating the bug. Unfortunately, the architecture of this module is not documented and I don't feel like I understand it enough to offer a PR that would both fix the problem and be likely to be merged.
