### PR TITLE
Handling inline references in the main schema even when subSchemas are provided

### DIFF
--- a/lib/enjoi.js
+++ b/lib/enjoi.js
@@ -33,7 +33,7 @@ module.exports = function enjoi(schema, subSchemas) {
         id = value.substr(0, value.indexOf('#') + 1);
         path = value.substr(value.indexOf('#') + 1);
 
-        if (id && subSchemas) {
+        if (id && id.length > 1 && subSchemas) {
             refschema = subSchemas[id] || subSchemas[id.substr(0, id.length - 1)];
         }
         else {

--- a/test/test-enjoi.js
+++ b/test/test-enjoi.js
@@ -105,6 +105,38 @@ Test('enjoi', function (t) {
         });
     });
 
+    t.test('with both inline and external refs', function (t) {
+        t.plan(1);
+
+        var schema = Enjoi({
+            'title': 'Example Schema',
+            'type': 'object',
+            'properties': {
+                'firstname': {
+                    '$ref': '#/definitions/firstname'
+                },
+		'surname': {
+                    '$ref': 'definitions#/surname'
+                }
+            },
+	    'definitions': {
+                'firstname': {
+		    'type': 'string'
+		}
+	    }
+        }, {
+            'definitions': {
+                'surname': {
+                    'type': 'string'
+                }
+            }
+        });
+
+        Joi.validate({firstname: 'Joe', surname: 'Doe'}, schema,  function (error, value) {
+            t.ok(!error, 'no error.');
+        });
+    });
+
 });
 
 Test('types', function (t) {


### PR DESCRIPTION
Right now, if `subSchemas` are provided, it prevents inline references in the main schema from being resolved.


```javascript```
var schema = Enjoi({
    'title': 'Example Schema',
    'type': 'object',
    'properties': {
        'firstname': {
            '$ref': '#/definitions/firstname'
        },
        'surname': {
            '$ref': 'definitions#/surname'
        }
    },
    'definitions': {
        'firstname': {
            'type': 'string'
        }
    }
}, {
    'definitions': {
        'surname': {
            'type': 'string'
        }
    }
});
```

Would throw up this error:
```
AssertionError: Can not find schema reference: #/definitions/firstname.
```

This PR fixes just that + adds proper test checking this use case.

(related: https://github.com/krakenjs/swaggerize-builder/issues/33 ).