### PR TITLE
#1 Datetime, date and email format validation, full enum support

### DIFF
--- a/lib/enjoi.js
+++ b/lib/enjoi.js
@@ -179,7 +179,20 @@ module.exports = function enjoi(schema, options) {
 
     function string(current) {
         var joischema = Joi.string();
+        
+        switch (current.format) {
+            case 'email':
+                joischema = email(current);
+                break;
+            default:
+                joischema = regularString(current);
+                break;
+        }
+        return joischema;
+    }
 
+    function regularString(current) {
+        var joischema = Joi.string();
         current.pattern && (joischema = joischema.regex(new RegExp(current.pattern)));
 
         if (Thing.isNumber(current.minLength)) {
@@ -190,7 +203,12 @@ module.exports = function enjoi(schema, options) {
         }
 
         Thing.isNumber(current.maxLength) && (joischema = joischema.max(current.maxLength));
+        return joischema;
+    }
 
+    function email(current) {
+        var joischema = Joi.string().email();
+        Thing.isNumber(current.maxLength) && (joischema = joischema.max(current.maxLength));
         return joischema;
     }
 

--- a/lib/enjoi.js
+++ b/lib/enjoi.js
@@ -181,6 +181,10 @@ module.exports = function enjoi(schema, options) {
         var joischema = Joi.string();
         
         switch (current.format) {
+            case 'date':
+            case 'date-time':
+                joischema = date(current);
+                break;
             case 'email':
                 joischema = email(current);
                 break;
@@ -209,6 +213,13 @@ module.exports = function enjoi(schema, options) {
     function email(current) {
         var joischema = Joi.string().email();
         Thing.isNumber(current.maxLength) && (joischema = joischema.max(current.maxLength));
+        return joischema;
+    }
+
+    function date(current) {
+        var joischema = Joi.date();
+        current.min && (joischema = joischema.min(current.min));
+        current.max && (joischema = joischema.max(current.max));
         return joischema;
     }
 

--- a/lib/enjoi.js
+++ b/lib/enjoi.js
@@ -35,6 +35,7 @@ module.exports = function enjoi(schema, options) {
             return resolve(resolveref(current.$ref));
         }
 
+        //if no type is specified, just enum
         if (current.enum) {
             return Joi.any().valid(current.enum);
         }
@@ -180,6 +181,10 @@ module.exports = function enjoi(schema, options) {
     function string(current) {
         var joischema = Joi.string();
         
+        if (current.enum) {
+            return Joi.any().valid(current.enum);
+        }
+
         switch (current.format) {
             case 'date':
             case 'date-time':

--- a/test/test-enjoi.js
+++ b/test/test-enjoi.js
@@ -367,7 +367,7 @@ Test('types', function (t) {
     });
 
     t.test('enum', function (t) {
-        t.plan(3);
+        t.plan(5);
 
         var schema = Enjoi({
             'enum': ['A', 'B']
@@ -377,6 +377,19 @@ Test('types', function (t) {
             t.ok(!error, 'no error.');
         });
 
+        Joi.validate('B', schema, function (error, value) {
+            t.ok(!error, 'no error.');
+        });
+
+        Joi.validate('C', schema, function (error, value) {
+            t.ok(error, 'error.');
+        });
+        
+        schema = Enjoi({
+            type: 'string',
+            'enum': ['A', 'B']
+        });
+        
         Joi.validate('B', schema, function (error, value) {
             t.ok(!error, 'no error.');
         });

--- a/test/test-enjoi.js
+++ b/test/test-enjoi.js
@@ -311,6 +311,40 @@ Test('types', function (t) {
 
        
     });
+    
+     t.test('string date ISO 8601', function (t) {
+        t.plan(5);
+
+        var schema = Enjoi({
+            'type': 'string',
+            'format': 'date',
+            'min': '1-1-2000 UTC',
+            'max': Date.now()
+        });
+
+        Joi.validate('1akd2536', schema, function (error, value) {
+            t.ok(error, "wrong date format.");
+        });
+        
+        Joi.validate('12-10-1900 UTC', schema, function (error, value) {
+            t.ok(error, "minimum date.");
+        });
+        
+       
+        
+        Joi.validate(Date.now() + 1000000, schema, function (error, value) {
+            t.ok(error, "maximum date.");
+        });
+        
+        Joi.validate('1-2-2015 UTC', schema, function (error, value) {
+            t.ok(!error,  "good date.");
+        });
+        
+         Joi.validate('2005-01-01', schema, function (error, value) {
+            t.ok(!error, "good date 2");
+        });
+
+    });
 
     t.test('no type, ref, or enum validates anything.', function (t) {
         t.plan(3);

--- a/test/test-enjoi.js
+++ b/test/test-enjoi.js
@@ -292,6 +292,26 @@ Test('types', function (t) {
         });
     });
 
+    t.test('string email', function (t) {
+        t.plan(2);
+
+        var schema = Enjoi({
+            'type': 'string',
+            'format': 'email',
+            'maxLength': '20'
+        });
+
+        Joi.validate('wrongemail', schema, function (error, value) {
+            t.ok(error, "wrong email error.");
+        });
+
+        Joi.validate('right@email.com', schema, function (error, value) {
+            t.ok(!error,  "good email.");
+        });
+
+       
+    });
+
     t.test('no type, ref, or enum validates anything.', function (t) {
         t.plan(3);
 


### PR DESCRIPTION
Adding support for "format" field of "string" type validation:
* date and date-time in ISO 8601 format
* email
* enum when format: string is provided 

It is not very clear that type must be specified when using enum in swagger 2.0 spec, but all offcial example use both:

```yaml
    huntingSkill:
        type: string
        description: The measured skill for hunting
        default: lazy
        enum:
          - clueless
          - lazy
          - adventurous
          - aggressive
```