### PR TITLE
Validate when additionalProperties is boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Here is a list of some missing keyword support still being worked on:
 - `not`
 - `format`
 - `object:patternProperties`
-- `object:additionalProperties`
+- `object:additionalProperties` (supported as a boolean, not supported as a schema).
 - `array:items` (supports as single schema, not supported as array of schemas).
 - `array:additionalItems`
 

--- a/lib/enjoi.js
+++ b/lib/enjoi.js
@@ -156,6 +156,10 @@ module.exports = function enjoi(schema, options) {
     function object(current) {
         var joischema = Joi.object(resolveproperties(current));
 
+        if (current.additionalProperties === true) {
+            joischema = joischema.unknown(true);
+        }
+
         Thing.isNumber(current.minProperties) && (joischema = joischema.min(current.minProperties));
         Thing.isNumber(current.maxProperties) && (joischema = joischema.max(current.maxProperties));
 

--- a/test/test-enjoi.js
+++ b/test/test-enjoi.js
@@ -577,4 +577,35 @@ Test('types', function (t) {
         });
     });
 
+    t.test('additionalProperties boolean', function (t) {
+        t.plan(4);
+
+        var schema = {
+            type: 'object',
+            properties: {
+                file: {
+                    type: 'string'
+                }
+            }
+        };
+
+        Enjoi(schema).validate({ file: 'data', consumes: 'application/json' }, function (error, value) {
+            t.ok(error, 'error.');
+        });
+
+        schema.additionalProperties = false;
+        Enjoi(schema).validate({ file: 'data', consumes: 'application/json' }, function (error, value) {
+            t.ok(error, 'error.');
+        });
+
+        schema.additionalProperties = true;
+        Enjoi(schema).validate({ file: 'data', consumes: 'application/json' }, function (error, value) {
+            t.ok(!error, 'no error.');
+        });
+
+        Enjoi(schema).validate({ file: 5, consumes: 'application/json' }, function (error, value) {
+            t.ok(error, 'error.');
+        });
+    });
+
 });


### PR DESCRIPTION
Initial work done by jsdevel - still does not support when this is a
schema object due to circular schema references and no current ability
to get a list of keys that didn't pass validation.