### PR TITLE
Update to joi 9.x.x

### DIFF
--- a/lib/enjoi.js
+++ b/lib/enjoi.js
@@ -3,6 +3,7 @@
 var Assert = require('assert');
 var Joi = require('joi');
 var Thing = require('core-util-is');
+var Alternatives = Object.getPrototypeOf(require('joi/lib/alternatives')).constructor;
 
 module.exports = function enjoi(schema, options) {
     var subSchemas, types;
@@ -219,11 +220,11 @@ module.exports = function enjoi(schema, options) {
     function regularString(current) {
         var joischema = Joi.string();
         current.pattern && (joischema = joischema.regex(new RegExp(current.pattern)));
-        
+
         if (Thing.isUndefined(current.minLength)) {
           current.minLength = 0;
         }
-        
+
         if (Thing.isNumber(current.minLength)) {
             if (current.minLength === 0) {
                 joischema = joischema.allow('');
@@ -252,14 +253,14 @@ module.exports = function enjoi(schema, options) {
 };
 
 
-function All() {
-    All.super_.call(this);
+class All extends Alternatives {
+  constructor() {
+    super();
     this._type = 'all';
     this._invalids.remove(null);
     this._inner.matches = [];
+  }
 }
-
-require('util').inherits(All, Object.getPrototypeOf(require('joi/lib/alternatives')).constructor);
 
 All.prototype._base = function (value, state, options) {
     var errors = [];

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/tlivings/enjoi",
   "dependencies": {
     "core-util-is": "^1.0.1",
-    "joi": "^6.4.3"
+    "joi": "^9.0.4"
   },
   "devDependencies": {
     "hammertime": "^0.1.2",


### PR DESCRIPTION
In order to support HAPI 14+, it requires compatibility with joi 9+. I'm not sure what your target platform is, but with this rewrite it will require node4+ as well, which joi already do so that seemed fine. 

However, it should probably be a major version upgrade. 
