### PR TITLE
Allow use of node versions greater than 4.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "git://github.com/tlivings/enjoi.git"
   },
   "engines": {
-    "node": "4.x"
+    "node": ">=4.x"
   },
   "keywords": [
     "joi",


### PR DESCRIPTION
Right now, the package.json explicitly specifies the version of node to run on. For some tools (like [yarn](https://yarnpkg.com/)), the default is to emit errors without extra configuration.

This changes the package.json ([in accordance with the spec](https://docs.npmjs.com/files/package.json#engines)) to allow versions of node greater than 4. This is needed because node major versions are incrementing [much faster than they used to](https://nodejs.org/en/blog/community/v5-to-v7/).