### PR TITLE
Allow shorthand for type only schemas

### DIFF
--- a/lib/enjoi.js
+++ b/lib/enjoi.js
@@ -8,7 +8,7 @@ const Alternatives = require('joi/lib/alternatives').constructor;
 module.exports = function enjoi(schema, options) {
     options = options || {};
 
-    Assert.ok(Thing.isObject(schema), 'Expected schema to be an object.');
+    Assert.ok(Thing.isObject(schema) || Thing.isString(schema), 'Expected schema to be an object or type string.');
     Assert.ok(Thing.isObject(options), 'Expected options to be an object.');
 
     const subSchemas = options.subSchemas;
@@ -41,6 +41,11 @@ module.exports = function enjoi(schema, options) {
         //if no type is specified, just enum
         if (current.enum) {
             return Joi.any().valid(current.enum);
+        }
+
+        // If current is itself a string, interpret it as a type
+        if (typeof current === 'string') {
+            return resolvetype({ type: current });
         }
 
         //Fall through to whatever.

--- a/test/test-enjoi.js
+++ b/test/test-enjoi.js
@@ -371,6 +371,31 @@ Test('types', function (t) {
         });
     });
 
+    t.test('shorthand type', function (t) {
+        t.plan(1);
+
+        var schema = Enjoi('string');
+        Joi.validate('A', schema, function (error, value) {
+            t.ok(!error, 'no error.');
+        });
+    });
+
+
+    t.test('shorthand property type', function (t) {
+        t.plan(1);
+
+        var schema = Enjoi({
+            'type': 'object',
+            'properties': {
+                'name': 'string'
+            }
+        });
+
+        Joi.validate({ name: 'test' }, schema, function (error, value) {
+            t.ok(!error, 'no error.');
+        });
+    });
+
     t.test('enum', function (t) {
         t.plan(5);
 


### PR DESCRIPTION
This allows you to use a simple string for a type instead of an entire object if you just want to validate the type;

e.g.
```
Enjoi('string').validate(val)
```
or
```
var schema = Enjoi({ properties: { name: 'string', age: 'number' } })
```