### PR TITLE
Add support for an any type

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ var schema = Enjoi({
     }
 });
 ```
+### Default Types
+- `'array'`
+- `'boolean'`
+- `'integer'`
+- `'number'`
+- `'object'`
+- `'string'`
+- `'any'`
 
 ### Custom Types
 

--- a/lib/enjoi.js
+++ b/lib/enjoi.js
@@ -93,6 +93,9 @@ module.exports = function enjoi(schema, options) {
             case 'string':
                 joischema = string(current);
                 break;
+            case 'any':
+                joischema = Joi.any();
+                break;
             default:
                 if (types) {
                     joischema = types[current.type];

--- a/test/test-enjoi.js
+++ b/test/test-enjoi.js
@@ -404,6 +404,42 @@ Test('types', function (t) {
         });
     });
 
+    t.test('any', function (t) {
+        t.plan(7);
+
+        var schema = Enjoi({
+            'type': 'any'
+        });
+
+        Joi.validate('A', schema, function (error, value) {
+            t.ok(!error, 'no error.');
+        });
+
+        Joi.validate(1, schema, function (error, value) {
+            t.ok(!error, 'no error.');
+        });
+
+        Joi.validate(true, schema, function (error, value) {
+            t.ok(!error, 'error.');
+        });
+
+        Joi.validate({}, schema, function (error, value) {
+            t.ok(!error, 'error.');
+        });
+
+        Joi.validate([], schema, function (error, value) {
+            t.ok(!error, 'error.');
+        });
+
+        Joi.validate(null, schema, function (error, value) {
+            t.ok(!error, 'error.');
+        });
+
+        Joi.validate(undefined, schema, function (error, value) {
+            t.ok(!error, 'error.');
+        });
+    });
+
     t.test('unknown type fails', function (t) {
         t.plan(1);
 


### PR DESCRIPTION
This allows you to explicitly specify the any type. The way it works right now it will default to any if nothing is specified but it also kicks out a `console.warn` message, which is fine as long as I have a way to avoid it.

I wanted a way to add a validator onto a property but not care about the type per-se:

```
var schema = Enjoi({
  type: 'object',
  properties: {
    example: 'any'
  }
})
```