### PR TITLE
Properties can specify required on themselves

### DIFF
--- a/lib/enjoi.js
+++ b/lib/enjoi.js
@@ -152,7 +152,7 @@ module.exports = function enjoi(schema, options) {
 
             let joischema = resolve(property);
 
-            if (current.required && !!~current.required.indexOf(key)) {
+            if (property.required || current.required && !!~current.required.indexOf(key)) {
                 joischema = joischema.required();
             }
 

--- a/test/test-enjoi.js
+++ b/test/test-enjoi.js
@@ -63,6 +63,30 @@ Test('enjoi', function (t) {
         });
     });
 
+    t.test('property can be required', function (t) {
+        t.plan(2);
+
+        var schema = Enjoi({
+            'title': 'Example Schema',
+            'description': 'An example to test against.',
+            'type': 'object',
+            'properties': {
+                'firstName': {
+                    'type': 'string',
+                    'required': true
+                }
+            }
+        });
+
+        Joi.validate({ firstName: 'John' }, schema, function (error, value) {
+            t.ok(!error, 'no error');
+        });
+
+        Joi.validate({ }, schema, function (error, value) {
+            t.ok(error, 'error');
+        });
+    });
+
     t.test('with ref', function (t) {
         t.plan(1);
 


### PR DESCRIPTION
This allows a property to specify `{ required: true }`

Simple convenience syntax but the case I hit was that I am only declaring the properties and the outter object part of the schema is not part of the definition, therefore I want a way to define this on the properties themselves rather than on the outter object.

e.g.
### Example schema creation
```js
  constructor(name, Component) {
    this.name = name
    this.component = Component
    this.instance = new Component()
    this.instance.node = this
    this.values = {}

    let metadata = Component.metadata
    console.log(`${metadata.name}`)
    let inputSchema = {
      title: `${metadata.name} inputs`,
      type: 'object',             // always wrapped in object schema
      properties: metadata.inputs // input properties are defined on Component
    }
    let outputSchema = {
      title: `${metadata.name} outputs`,
      type: 'object',              // always wrapped in object schema
      properties: metadata.outputs // output properties are defined on Component
    }
    this.inputs = Enjoi(inputSchema, schemaOptions)
    this.outputs = Enjoi(inputSchema, schemaOptions)
  }
```

### Example metadata
```js
  static get metadata() {
    return {
      name: 'property',
      inputs: {
        path: { type: 'string', required: true },
        object: { type: 'object', required: true }
      },
      outputs: {
        value: { }
      }
    }
  }
```