### PR TITLE
Fix additional properties

### DIFF
--- a/lib/enjoi.js
+++ b/lib/enjoi.js
@@ -193,7 +193,6 @@ module.exports = function enjoi(schema, options) {
         }
 
         if (Thing.isObject(current.additionalProperties)) {
-            console.log(current.additionalProperties);
             joischema = joischema.pattern(/^/, resolve(current.additionalProperties));
         }
 

--- a/lib/enjoi.js
+++ b/lib/enjoi.js
@@ -193,7 +193,8 @@ module.exports = function enjoi(schema, options) {
         }
 
         if (Thing.isObject(current.additionalProperties)) {
-            joischema = joischema.keys(resolveproperties({properties: current.additionalProperties}));
+            console.log(current.additionalProperties);
+            joischema = joischema.pattern(/^/, resolve(current.additionalProperties));
         }
 
         if (current.additionalProperties) {

--- a/test/test-enjoi.js
+++ b/test/test-enjoi.js
@@ -819,9 +819,7 @@ Test('types', function (t) {
              file: Enjoi({
                  type: 'object',
                  additionalProperties: {
-                     consumes: {
-                         type: 'string'
-                     }
+                     type: 'string'
                  },
                  properties: {
                      file: {
@@ -848,9 +846,7 @@ Test('types', function (t) {
              file: Enjoi({
                  type: 'object',
                  additionalProperties: {
-                     consumes: {
-                         type: 'string'
-                     }
+                     type: 'string'
                  },
                  properties: {
                      file: {
@@ -863,35 +859,6 @@ Test('types', function (t) {
 
      schema.validate({file: 'asdf', consumes: 5}, function (error, value) {
        t.ok(error);
-     });
-   });
-
-   t.test('additionalProperties object should also allow unkown properties', function(t) {
-     t.plan(1);
-
-     var schema = Enjoi({
-         type: 'file'
-       },
-       {
-         types: {
-             file: Enjoi({
-                 type: 'object',
-                 additionalProperties: {
-                     consumes: {
-                         type: 'string'
-                     }
-                 },
-                 properties: {
-                     file: {
-                         type: 'string'
-                     }
-                 }
-             })
-         }
-     });
-
-     schema.validate({file: 'asdf', consumes: 'application/json', test: 5}, function (error, value) {
-       t.ok(!error);
      });
    });
 


### PR DESCRIPTION
According the documentation https://spacetelescope.github.io/understanding-json-schema/reference/object.html

> If additionalProperties is an object, that object is a schema that will be used to validate any additional properties not listed in properties.

```json
{
  "type": "object",
  "properties": {
    "number":      { "type": "number" },
    "street_name": { "type": "string" },
    "street_type": { "type": "string",
                     "enum": ["Street", "Avenue", "Boulevard"]
                   }
  },
  "additionalProperties": { "type": "string" }
}
```