### PR TITLE
Do not overwrite stripUnknown on the passed in options since those ma…

### DIFF
--- a/lib/enjoi.js
+++ b/lib/enjoi.js
@@ -315,11 +315,7 @@ class All extends Alternatives {
         let errors = [];
         const results = [];
 
-        if (!options) {
-            options = {};
-        }
-
-        options.stripUnknown = true;
+        options = Object.assign({}, options, { stripUnknown: true });
 
         for (let i = 0, il = this._inner.matches.length; i < il; ++i) {
             const item = this._inner.matches[i];


### PR DESCRIPTION
…y be shared above enjoi

I'm not entirely sure why it's all happening, but basically this can break validation of methods that have top level array body arguments (at least) because of the order in which validators are created/called.