### PR TITLE
Proper items() and ordered() support for arrays

### DIFF
--- a/lib/enjoi.js
+++ b/lib/enjoi.js
@@ -53,6 +53,17 @@ module.exports = function enjoi(schema, options) {
         return Joi.any();
     }
 
+    // Resolve a value as if it was an array, a single value is translated to an array of one item
+    function resolveAsArray(value) {
+        if (Thing.isArray(value)) {
+            // found an array, thus its _per type_
+            return value.map(function (v) { return resolve(v); });
+        } else {
+            // it's a single entity, so just resolve it normally
+            return [resolve(value)];
+        }
+    }
+
     function resolveref(value) {
         let refschema;
 
@@ -209,7 +220,11 @@ module.exports = function enjoi(schema, options) {
     function array(current) {
         let joischema = Joi.array();
 
-        joischema = joischema.items(resolve(current.items));
+        if (current.items) {
+            joischema = joischema.items(resolveAsArray(current.items));
+        } else if (current.ordered) {
+            joischema = joischema.ordered(resolveAsArray(current.ordered));
+        }
 
         Thing.isNumber(current.minItems) && (joischema = joischema.min(current.minItems));
         Thing.isNumber(current.maxItems) && (joischema = joischema.max(current.maxItems));

--- a/test/test-enjoi.js
+++ b/test/test-enjoi.js
@@ -193,6 +193,96 @@ Test('types', function (t) {
         });
     });
 
+    t.test('arrays with specific item type assignment', function (t) {
+        t.plan(7);
+
+        var schema = Enjoi({
+          'type': 'array',
+          'items': [
+              {
+                'type': 'number'
+              }, {
+                'type': 'string'
+              }
+          ],
+        });
+
+        Joi.validate([1, 'abc'], schema, function (error) {
+            t.ok(!error, 'no error.');
+        });
+
+        Joi.validate([0, 1], schema, function (error) {
+            t.ok(!error, 'no error.');
+        });
+
+        Joi.validate(['abc', 'def'], schema, function (error) {
+            t.ok(!error, 'no error.');
+        });
+
+        Joi.validate([1], schema, function (error) {
+            t.ok(!error, 'no error.');
+        });
+
+        Joi.validate(['abc'], schema, function (error) {
+            t.ok(!error, 'no error.');
+        });
+
+        Joi.validate([], schema, function (error) {
+            t.ok(!error, 'no error.');
+        });
+
+        Joi.validate([{ foo: 'bar' }], schema, function (error) {
+            t.ok(error, 'error.');
+        });
+    });
+
+    t.test('arrays with ordered item assignment', function (t) {
+        t.plan(8);
+
+        var schema = Enjoi({
+          'type': 'array',
+          'ordered': [
+            {
+              'type': 'number'
+            }, {
+              'type': 'string'
+            }
+          ],
+        });
+
+        Joi.validate([1, 'abc'], schema, function (error) {
+            t.ok(!error, 'no error.');
+        });
+
+        Joi.validate([], schema, function (error) {
+            t.ok(!error, 'no error.');
+        });
+
+        Joi.validate([0, 1], schema, function (error) {
+            t.ok(error, 'error.');
+        });
+
+        Joi.validate(['abc', 'def'], schema, function (error) {
+            t.ok(error, 'error.');
+        });
+
+        Joi.validate([1], schema, function (error) {
+            t.ok(!error, 'no error.');
+        });
+
+        Joi.validate(['abc'], schema, function (error) {
+            t.ok(error, 'error.');
+        });
+
+        Joi.validate([{ foo: 'bar' }], schema, function (error) {
+            t.ok(error, 'error.');
+        });
+
+        Joi.validate([1, 'abc', 'def'], schema, function (error) {
+            t.ok(error, 'error.');
+        });
+    });
+
     t.test('arrays and refs', function (t) {
         t.plan(2);
 


### PR DESCRIPTION
This adds the support for `items()` and `ordered()` into the array syntax (I needed ordered 😀).

Closes #2.