### PR TITLE
Feature/extend joi validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Please file issues for other unsupported features.
 - `refineType(type, format)` - an (optional) function to call to apply to type based on the type and format of the JSON schema.
 - `extensions` - an array of extensions to pass [joi.extend](https://github.com/hapijs/joi/blob/master/API.md#extendextension).
 - `strictMode` - make schemas `strict(value)` with a default value of `false`.
+- `warnOnEmpty` - outputs a warning message on console if a schema is empty or considered empty - https://json-schema.org/latest/json-schema-core.html#rfc.section.4.3.1
+- `extendValidation` - gives the ability to extend the default joi validation schema produced by `enjoi`. Works for the root schema and for references.
 
 Example:
 
@@ -216,3 +218,55 @@ const schema = Enjoi.schema({
     ]
 });
 ```
+
+### Extend Joi validation
+
+Example with root schema:
+```javascript
+const schema = Enjoi.schema({
+    type: 'object',
+    properties: {
+        title: {type: 'string'},
+    },
+    definitions: {
+        Name: {
+            type: 'string'
+        }
+    }
+}, {
+    extendValidation: {
+        '#': Joi.object().keys({title: Joi.string().max(3)}),
+    }
+});
+```
+
+Example with root schema and references:
+```javascript
+const schema = Enjoi.schema({
+    type: 'object',
+    properties: {
+        title: {type: 'string'},
+        name: {$ref: '#/definitions/Name'},
+        address: {$ref: 'definitions#/Address'}
+    },
+    definitions: {
+        Name: {
+            type: 'string'
+        }
+    }
+}, {
+    subSchemas: {
+        'definitions': {
+            'Address': {
+                'type': 'string'
+            }
+        }
+    },
+    extendValidation: {
+        '#': Joi.object().keys({title: Joi.string().max(3)}),
+        '#/definitions/Name': Joi.string().max(8),
+        'definitions#/Address': Joi.string().max(7)
+    }
+});
+```
+

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const optionsSchema = Joi.object({
     refineType: Joi.func().allow(null),
     strictMode: Joi.boolean().default(false),
     extendValidation: Joi.object().pattern(/^#(\/\S*)*$/, Joi.object().schema()),
+    warnOnEmpty: Joi.boolean(),
 });
 
 const validate = function (schema, options = {}) {
@@ -37,6 +38,7 @@ exports.defaults = function (defaults = {}) {
                 refineType: options.refineType || defaults.refineType,
                 strictMode: options.strictMode || defaults.strictMode,
                 extendValidation: options.extendValidation || {},
+                warnOnEmpty: options.warnOnEmpty || true,
             };
             if (Util.isArray(options.extensions)) {
                 merged.extensions = merged.extensions.concat(options.extensions);

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const optionsSchema = Joi.object({
     extensions: Joi.array().items(Joi.object().unknown(true)).allow(null),
     refineType: Joi.func().allow(null),
     strictMode: Joi.boolean().default(false),
+    extendValidation: Joi.object().pattern(/^#(\/\S*)*$/, Joi.object().schema()),
 });
 
 const validate = function (schema, options = {}) {
@@ -34,7 +35,8 @@ exports.defaults = function (defaults = {}) {
                 types: Object.assign({}, defaults.types, options.types),
                 extensions: defaults.extensions || [],
                 refineType: options.refineType || defaults.refineType,
-                strictMode: options.strictMode || defaults.strictMode
+                strictMode: options.strictMode || defaults.strictMode,
+                extendValidation: options.extendValidation || {},
             };
             if (Util.isArray(options.extensions)) {
                 merged.extensions = merged.extensions.concat(options.extensions);

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const optionsSchema = Joi.object({
     extensions: Joi.array().items(Joi.object().unknown(true)).allow(null),
     refineType: Joi.func().allow(null),
     strictMode: Joi.boolean().default(false),
-    extendValidation: Joi.object().pattern(/^#(\/\S*)*$/, Joi.object().schema()),
+    extendValidation: Joi.object().pattern(/^\S*#(\/\S*)*$/, Joi.object().schema()),
     warnOnEmpty: Joi.boolean(),
 });
 

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -10,8 +10,8 @@ class SchemaResolver {
         this.subSchemas = subSchemas;
         this.refineType = refineType;
         this.strictMode = strictMode;
-        this.extendValidation = extendValidation;
-        this.warnOnEmpty = warnOnEmpty;
+        this.extendValidation = extendValidation || {};
+        this.warnOnEmpty = warnOnEmpty || true;
 
         extensions.push({
             name: 'allOf',
@@ -165,8 +165,7 @@ class SchemaResolver {
                         if (Util.isFunction(customType)) {
                             joischema = customType.call(this.joi, schema);
                         }
-                        
-{
+                        else {
                             joischema = customType;
                         }
                     }
@@ -186,8 +185,7 @@ class SchemaResolver {
 
             joischema = this.joi.alternatives(schemas);
         }
-        
-{
+        else {
             joischema = joitype(schema.type, schema.format);
         }
 
@@ -288,8 +286,7 @@ class SchemaResolver {
     
             joischema = joischema.items(items);
         }
-        
-if (schema.ordered) {
+        else if (schema.ordered) {
             items = resolveAsArray(schema.ordered);
             joischema = joischema.ordered(items);
         }

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -4,13 +4,14 @@ const Util = require('util');
 const Hoek = require('hoek');
 
 class SchemaResolver {
-    constructor(root, { subSchemas, types, refineType, strictMode, extensions = [] }) {
+    constructor(root, { subSchemas, types, refineType, strictMode, extendValidation, extensions = [] }) {
         this.root = root;
         this.types = types;
         this.subSchemas = subSchemas;
         this.refineType = refineType;
         this.strictMode = strictMode;
-        
+        this.extendValidation = extendValidation;
+
         extensions.push({
             name: 'allOf',
             rules: [{
@@ -38,47 +39,51 @@ class SchemaResolver {
 
         this.joi = Joi.extend(extensions);
     }
+
+    extendJoiSchema(joiSchema, ref) {
+        return this.extendValidation[ref] ?
+            joiSchema = joiSchema.concat(this.extendValidation[ref]) :
+            joiSchema;
+    }
     
     resolve(schema = this.root) {
+        let joiSchema;
         if (schema.type) {
-            return this.resolveType(schema);
+            joiSchema = this.resolveType(schema);
+        } else if (schema.anyOf) {
+            joiSchema =  this.resolveAnyOf(schema);
+        } else if (schema.allOf) {
+            joiSchema =  this.resolveAllOf(schema.allOf);
+        } else if (schema.oneOf) {
+            joiSchema =  this.resolveOneOf(schema);
+        } else if (schema.not) {
+            joiSchema =  this.resolveNot(schema);
+        } else if (schema.$ref) {
+            // extend any referenced schema
+            joiSchema = this.extendJoiSchema(
+                this.resolve(this.resolveReference(schema.$ref)),
+                schema.$ref,
+            );
+        } else if (schema.enum) {
+            //if no type is specified, just enum
+            joiSchema =  this.joi.any().valid(schema.enum);
+        } else if (typeof schema === 'string') {
+            // If schema is itself a string, interpret it as a type
+            joiSchema =  this.resolveType({ type: schema });
+        } else {
+            //Fall through to whatever.
+            //eslint-disable-next-line no-console
+            console.warn('WARNING: schema missing a \'type\' or \'$ref\' or \'enum\': \n%s', JSON.stringify(schema, null, 2));
+            //TODO: Handle better
+            joiSchema =  this.joi.any();
         }
 
-        if (schema.anyOf) {
-            return this.resolveAnyOf(schema);
+        if (schema === this.root) {
+            // extend the root schema
+            joiSchema = this.extendJoiSchema(joiSchema, '#');
         }
 
-        if (schema.allOf) {
-            return this.resolveAllOf(schema.allOf);
-        }
-
-        if (schema.oneOf) {
-            return this.resolveOneOf(schema);
-        }
-
-        if (schema.not) {
-            return this.resolveNot(schema);
-        }
-
-        if (schema.$ref) {
-            return this.resolve(this.resolveReference(schema.$ref));
-        }
-
-        //if no type is specified, just enum
-        if (schema.enum) {
-            return this.joi.any().valid(schema.enum);
-        }
-
-        // If schema is itself a string, interpret it as a type
-        if (typeof schema === 'string') {
-            return this.resolveType({ type: schema });
-        }
-
-        //Fall through to whatever.
-        //eslint-disable-next-line no-console
-        console.warn('WARNING: schema missing a \'type\' or \'$ref\' or \'enum\': \n%s', JSON.stringify(schema, null, 2));
-        //TODO: Handle better
-        return this.joi.any();
+        return joiSchema;
     }
 
     resolveReference(value) {

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -54,13 +54,14 @@ class SchemaResolver {
         }
         
         if (schema.$ref) {
-            // extend any references schemas
+            // extend and resolve any referenced schemas
             return this.extendJoiSchema(
                 this.resolveSchema(this.resolveReference(schema.$ref)),
                 schema.$ref,
             );
         }
         
+        // resolve subschemas
         return this.resolveSchema(schema);
     }
 
@@ -93,7 +94,6 @@ class SchemaResolver {
         if (this.warnOnEmpty) {
             // eslint-disable-next-line no-console
             console.warn('WARNING: schema missing a \'type\' or \'$ref\' or \'enum\': \n%s', JSON.stringify(schema, null, 2));
-            console.log('\n\n\n\n\n\n\n\n');
         }
         return this.joi.any();
     }

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -4,13 +4,14 @@ const Util = require('util');
 const Hoek = require('hoek');
 
 class SchemaResolver {
-    constructor(root, { subSchemas, types, refineType, strictMode, extendValidation, extensions = [] }) {
+    constructor(root, { subSchemas, types, refineType, strictMode, extendValidation, warnOnEmpty, extensions = [] }) {
         this.root = root;
         this.types = types;
         this.subSchemas = subSchemas;
         this.refineType = refineType;
         this.strictMode = strictMode;
         this.extendValidation = extendValidation;
+        this.warnOnEmpty = warnOnEmpty;
 
         extensions.push({
             name: 'allOf',
@@ -64,32 +65,37 @@ class SchemaResolver {
     }
 
     resolveSchema(schema) {
-        let joiSchema;
         if (schema.type) {
-            joiSchema = this.resolveType(schema);
-        } else if (schema.anyOf) {
-            joiSchema =  this.resolveAnyOf(schema);
-        } else if (schema.allOf) {
-            joiSchema =  this.resolveAllOf(schema.allOf);
-        } else if (schema.oneOf) {
-            joiSchema =  this.resolveOneOf(schema);
-        } else if (schema.not) {
-            joiSchema =  this.resolveNot(schema);
-        } else if (schema.enum) {
+            return this.resolveType(schema);
+        } 
+        if (schema.anyOf) {
+            return this.resolveAnyOf(schema);
+        } 
+        if (schema.allOf) {
+            return this.resolveAllOf(schema.allOf);
+        } 
+        if (schema.oneOf) {
+            return this.resolveOneOf(schema);
+        } 
+        if (schema.not) {
+            return this.resolveNot(schema);
+        } 
+        if (schema.enum) {
             //if no type is specified, just enum
-            joiSchema =  this.joi.any().valid(schema.enum);
-        } else if (typeof schema === 'string') {
+            return this.joi.any().valid(schema.enum);
+        } 
+        if (typeof schema === 'string') {
             // If schema is itself a string, interpret it as a type
-            joiSchema =  this.resolveType({ type: schema });
-        } else {
-            //Fall through to whatever.
-            //eslint-disable-next-line no-console
-            console.warn('WARNING: schema missing a \'type\' or \'$ref\' or \'enum\': \n%s', JSON.stringify(schema, null, 2));
-            //TODO: Handle better
-            joiSchema =  this.joi.any();
-        }
+            return this.resolveType({ type: schema });
+        } 
 
-        return joiSchema;
+        // interpret as empty schema and always validate
+        if (this.warnOnEmpty) {
+            // eslint-disable-next-line no-console
+            console.warn('WARNING: schema missing a \'type\' or \'$ref\' or \'enum\': \n%s', JSON.stringify(schema, null, 2));
+            console.log('\n\n\n\n\n\n\n\n');
+        }
+        return this.joi.any();
     }
 
     resolveReference(value) {
@@ -159,7 +165,8 @@ class SchemaResolver {
                         if (Util.isFunction(customType)) {
                             joischema = customType.call(this.joi, schema);
                         }
-                        else {
+                        
+{
                             joischema = customType;
                         }
                     }
@@ -179,7 +186,8 @@ class SchemaResolver {
 
             joischema = this.joi.alternatives(schemas);
         }
-        else {
+        
+{
             joischema = joitype(schema.type, schema.format);
         }
 
@@ -280,7 +288,8 @@ class SchemaResolver {
     
             joischema = joischema.items(items);
         }
-        else if (schema.ordered) {
+        
+if (schema.ordered) {
             items = resolveAsArray(schema.ordered);
             joischema = joischema.ordered(items);
         }

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -46,7 +46,24 @@ class SchemaResolver {
             joiSchema;
     }
     
-    resolve(schema = this.root) {
+    resolve(schema) {
+        if (!schema) {
+            // extend and resolve the root schema
+            return this.extendJoiSchema(this.resolveSchema(this.root), '#');
+        }
+        
+        if (schema.$ref) {
+            // extend any references schemas
+            return this.extendJoiSchema(
+                this.resolveSchema(this.resolveReference(schema.$ref)),
+                schema.$ref,
+            );
+        }
+        
+        return this.resolveSchema(schema);
+    }
+
+    resolveSchema(schema) {
         let joiSchema;
         if (schema.type) {
             joiSchema = this.resolveType(schema);
@@ -58,12 +75,6 @@ class SchemaResolver {
             joiSchema =  this.resolveOneOf(schema);
         } else if (schema.not) {
             joiSchema =  this.resolveNot(schema);
-        } else if (schema.$ref) {
-            // extend any referenced schema
-            joiSchema = this.extendJoiSchema(
-                this.resolve(this.resolveReference(schema.$ref)),
-                schema.$ref,
-            );
         } else if (schema.enum) {
             //if no type is specified, just enum
             joiSchema =  this.joi.any().valid(schema.enum);
@@ -76,11 +87,6 @@ class SchemaResolver {
             console.warn('WARNING: schema missing a \'type\' or \'$ref\' or \'enum\': \n%s', JSON.stringify(schema, null, 2));
             //TODO: Handle better
             joiSchema =  this.joi.any();
-        }
-
-        if (schema === this.root) {
-            // extend the root schema
-            joiSchema = this.extendJoiSchema(joiSchema, '#');
         }
 
         return joiSchema;

--- a/test/test-options.js
+++ b/test/test-options.js
@@ -201,3 +201,57 @@ Test('extensions', function (t) {
         t.ok(error, 'error.');
     });
 });
+
+Test('extending the Joi validation', function (t) {
+    t.test('extend root, inline and external refs', function(t) {
+        t.plan(4);
+        
+        const schema = Enjoi.schema({
+            type: 'object',
+            properties: {
+                title: {type: 'string'},
+                name: {$ref: '#/definitions/Name'},
+                address: {$ref: 'definitions#/Address'}
+            },
+            definitions: {
+                Name: {
+                    type: 'string'
+                }
+            }
+        }, {
+            subSchemas: {
+                'definitions': {
+                    'Address': {
+                        'type': 'string'
+                    }
+                }
+            },
+            extendValidation: {
+                '#': Joi.object().keys({title: Joi.string().max(3)}),
+                '#/definitions/Name': Joi.string().max(8),
+                'definitions#/Address': Joi.string().max(7)
+            }
+        });
+
+        const data = {
+            title: 'mr.',
+            name: 'John Doe',
+            address: 'Earth'
+        };
+        Joi.validate(data, schema, function (error, value) {
+            t.ok(!error, 'no error.');
+        });
+
+        Joi.validate({title: 'mister'}, schema, function (error, value) {
+            t.ok(error, 'error.');
+        });
+
+        Joi.validate({name: 'Jonathan Doe'}, schema, function (error, value) {
+            t.ok(error, 'error.');
+        });
+
+        Joi.validate({address: 'Earth, Milky Way'}, schema, function (error, value) {
+            t.ok(error, 'error.');
+        });
+    });
+});


### PR DESCRIPTION
Resolves #65 + some small additions

* Able to extend the default Joi validation schema produced by `enjoi`
* Make console warning on empty schema configurable through `options` - an empty schema or one that is considered empty is valid, so the warning should be removable. Refer to https://json-schema.org/latest/json-schema-core.html#rfc.section.4.3.1. The default value of the option is left to `true` to avoid breaking changes.
* Tests and documentation covering the new functionality