### PR TITLE
chore: move dependencies for joi and hoek

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 
-const Joi = require('joi');
-const Hoek = require('hoek');
+const Joi = require('@hapi/joi');
+const Hoek = require('@hapi/hoek');
 const Util = require('util');
 const SchemaResolver = require('./lib/resolver');
 

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -1,7 +1,7 @@
 
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 const Util = require('util');
-const Hoek = require('hoek');
+const Hoek = require('@hapi/hoek');
 
 class SchemaResolver {
     constructor(root, { subSchemas, types, refineType, strictMode, extensions = [] }) {

--- a/package.json
+++ b/package.json
@@ -47,13 +47,13 @@
   },
   "homepage": "https://github.com/tlivings/enjoi",
   "dependencies": {
-    "hoek": "^6.0.0"
+    "@hapi/hoek": "^6.0.0"
   },
   "peerDependencies": {
-    "joi": "^14.0.0"
+    "@hapi/joi": "^14.0.0"
   },
   "devDependencies": {
-    "joi": "^14.0.0",
+    "@hapi/joi": "^14.0.0",
     "eslint": "^5.0.0",
     "nyc": "^13.0.0",
     "tape": "^4.9.0"

--- a/test/test-directives.js
+++ b/test/test-directives.js
@@ -1,7 +1,7 @@
 
 const Test = require('tape');
 const Enjoi = require('../index');
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 
 Test('directives', function (t) {
     t.test('anyOf', function (t) {

--- a/test/test-enjoi.js
+++ b/test/test-enjoi.js
@@ -1,7 +1,7 @@
 
 const Test = require('tape');
 const Enjoi = require('../index');
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 
 Test('enjoi', function (t) {
 

--- a/test/test-options.js
+++ b/test/test-options.js
@@ -1,7 +1,7 @@
 
 const Test = require('tape');
 const Enjoi = require('../index');
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 
 Test('options features', function (t) {
 

--- a/test/test-types.js
+++ b/test/test-types.js
@@ -1,7 +1,7 @@
 
 const Test = require('tape');
 const Enjoi = require('../index');
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 
 Test('types', function (t) {
 


### PR DESCRIPTION
joi and hoek have been deprecated appear to have migrated to @hapi/joi and @hapi/hoek. Didn't see anything about this on the board so I'm posting it here. Did a quick swap out of the import statements and ran npm test which came back clean. Let me know if this has been addressed or you dont want to support the latest joi and hoek. Our security scanning software flagged hoek as having known vulnerabilities already, I'm not sure how valid that is, the software is not great, but we have to move away from enjoi if this isn't changed regardless. Have a nice day.

https://www.npmjs.com/package/joi
https://www.npmjs.com/package/hoek