### PR TITLE
Support 'error' property

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -112,7 +112,8 @@ class SchemaResolver {
         const typeDefinitionMap = {
             description: 'description',
             title: 'label',
-            default: 'default'
+            default: 'default',
+            error: 'error'
         };
 
         const joitype = (type, format) => {


### PR DESCRIPTION
Noticed there was no support for the 'error' property, so I've added it to the typeDefinitionsMap to allow it to pass through to the joischema. Hopefully this was the right way to go about it, but let me know if there's a better way.

The Joi docs on 'error': https://github.com/hapijs/joi/blob/v15.0.3/API.md#anyerrorerr-options