### PR TITLE
Fix for #73: Empty string ignores regex string validation

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -351,9 +351,7 @@ class SchemaResolver {
     
         if (Util.isUndefined(schema.minLength)) {
             schema.minLength = 0;
-        }
-    
-        if (schema.minLength === 0) {
+        } else if (schema.minLength === 0) {
             joischema = joischema.allow('');
         }
         Util.isNumber(schema.minLength) && (joischema = joischema.min(schema.minLength));

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -10,13 +10,13 @@ class SchemaResolver {
         this.subSchemas = subSchemas;
         this.refineType = refineType;
         this.strictMode = strictMode;
-        
+
         extensions.push({
             name: 'allOf',
             rules: [{
                 name: 'items',
                 params: {
-                    items: Joi.array().items(Joi.object()).required()  
+                    items: Joi.array().items(Joi.object()).required()
                 },
                 validate(params, value, state, options) {
                     let error;
@@ -38,7 +38,7 @@ class SchemaResolver {
 
         this.joi = Joi.extend(extensions);
     }
-    
+
     resolve(schema = this.root) {
         if (schema.type) {
             return this.resolveType(schema);
@@ -215,46 +215,46 @@ class SchemaResolver {
 
         const resolveproperties = () => {
             const schemas = {};
-        
+
             if (!Util.isObject(schema.properties)) {
                 return;
             }
-        
+
             Object.keys(schema.properties).forEach((key) => {
                 const property = schema.properties[key];
-        
+
                 let joischema = this.resolve(property);
-        
+
                 if (schema.required && !!~schema.required.indexOf(key)) {
                     joischema = joischema.required();
                 }
-        
+
                 schemas[key] = joischema;
             });
-        
+
             return schemas;
         }
-    
+
         let joischema = this.joi.object(resolveproperties(schema));
-    
+
         if (schema.additionalProperties === true) {
             joischema = joischema.unknown(true);
         }
-    
+
         if (Util.isObject(schema.additionalProperties)) {
             joischema = joischema.pattern(/^/, this.resolve(schema.additionalProperties));
         }
-    
+
         Util.isNumber(schema.minProperties) && (joischema = joischema.min(schema.minProperties));
         Util.isNumber(schema.maxProperties) && (joischema = joischema.max(schema.maxProperties));
-    
+
         return joischema;
     }
-    
+
     array(schema) {
         let joischema = this.joi.array();
         let items;
-    
+
         const resolveAsArray = (value) => {
             if (Util.isArray(value)) {
                 // found an array, thus its _per type_
@@ -263,47 +263,47 @@ class SchemaResolver {
             // it's a single entity, so just resolve it normally
             return [this.resolve(value)];
         }
-    
+
         if (schema.items) {
             items = resolveAsArray(schema.items);
-    
+
             joischema = joischema.items(items);
         }
         else if (schema.ordered) {
             items = resolveAsArray(schema.ordered);
             joischema = joischema.ordered(items);
         }
-    
+
         if (items && schema.additionalItems === false) {
             joischema = joischema.max(items.length);
         }
-    
+
         Util.isNumber(schema.minItems) && (joischema = joischema.min(schema.minItems));
         Util.isNumber(schema.maxItems) && (joischema = joischema.max(schema.maxItems));
-    
+
         if (schema.uniqueItems) {
             joischema = joischema.unique();
         }
-    
+
         return joischema;
     }
-    
+
     number(schema) {
         let joischema = this.joi.number();
-    
+
         if (schema.type === 'integer') {
             joischema = joischema.integer();
         }
-    
+
         Util.isNumber(schema.minimum) && (joischema = joischema.min(schema.minimum));
         Util.isNumber(schema.maximum) && (joischema = joischema.max(schema.maximum));
         Util.isNumber(schema.exclusiveMinimum) && (joischema = joischema.greater(schema.exclusiveMinimum));
         Util.isNumber(schema.exclusiveMaximum) && (joischema = joischema.less(schema.exclusiveMaximum));
         Util.isNumber(schema.multipleOf) && schema.multipleOf !== 0 && (joischema = joischema.multiple(schema.multipleOf));
-    
+
         return joischema;
     }
-    
+
     string(schema) {
         let joischema = this.joi.string();
 
@@ -314,7 +314,7 @@ class SchemaResolver {
         if (schema.enum) {
             return this.joi.any().valid(schema.enum);
         }
-    
+
         switch (schema.format) {
             case 'date':
                 return joischema.regex(new RegExp('^' + dateRegex + '$', 'i'), 'JsonSchema date format');
@@ -345,20 +345,21 @@ class SchemaResolver {
         }
         return this.regularString(schema, joischema);
     }
-    
+
     regularString(schema, joischema) {
         schema.pattern && (joischema = joischema.regex(new RegExp(schema.pattern)));
-    
+
         if (Util.isUndefined(schema.minLength)) {
             schema.minLength = 0;
-        } else if (schema.minLength === 0) {
+        }
+        else if (schema.minLength === 0) {
             joischema = joischema.allow('');
         }
         Util.isNumber(schema.minLength) && (joischema = joischema.min(schema.minLength));
         Util.isNumber(schema.maxLength) && (joischema = joischema.max(schema.maxLength));
         return joischema;
     }
-    
+
     binary(schema) {
         let joischema = this.joi.binary();
         Util.isNumber(schema.minLength) && (joischema = joischema.min(schema.minLength));

--- a/test/test-types.js
+++ b/test/test-types.js
@@ -273,7 +273,7 @@ Test('types', function (t) {
     });
 
     t.test('string regex', function (t) {
-        t.plan(2);
+        t.plan(3);
 
         const schema = Enjoi.schema({
             'type': 'string',
@@ -284,11 +284,15 @@ Test('types', function (t) {
             t.ok(error, 'error.');
         });
 
+        Joi.validate('', schema, function (error, value) {
+            t.ok(error, 'error.');
+        });
+
         Joi.validate('foobar', schema, function (error, value) {
             t.ok(!error, 'no error.');
         });
     });
-
+    
     t.test('string length', function (t) {
         t.plan(3);
 


### PR DESCRIPTION
The previous fix for #73 did not fix the issue. I added simple test case to the code (below), where the empty string is passed to regex validation and it's returned as OK (that doesn't make sense).

Proposed fix is simple: let's NOT call "allow('')" if the minLength is not explicitly defined as 0.
