### PR TITLE
Fix usage of @hapi/joi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 
 
+### 6.0.2
+
+* Correct usage of @hapi/joi `validate` function. joiSchema.validate(obj) instead of Joi.validate(obj, joiSchema).
+
 ### 6.0.1
 
 * #83 differentiate between undefined and falsy

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Please file issues for other unsupported features.
     - `schema` - a JSON schema or a string type representation (such as `'integer'`).
     - `options` - an (optional) object of additional options such as `subSchemas` and custom `types`.
 - `enjoi.defaults(options)` - configure defaults `options` to be used with all `enjoi.schema` calls. `enjoi.schema` options passed will always override defaults set here.
-       
+
 ### Options
-        
+
 - `subSchemas` - an (optional) object with keys representing schema ids, and values representing schemas.
 - `types` - an (optional) object  with keys representing type names and values representing a Joi type. Values can also be functions that are expected to return Joi types. These functions have a context bound to the Joi being used by Enjoi and a single argument, `schema`, which represents the current schema being evaluated.
 - `refineType(type, format)` - an (optional) function to call to apply to type based on the type and format of the JSON schema.
@@ -32,7 +32,7 @@ Please file issues for other unsupported features.
 Example:
 
 ```javascript
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 const Enjoi = require('enjoi');
 
 const schema = Enjoi.schema({
@@ -55,9 +55,7 @@ const schema = Enjoi.schema({
     'required': ['firstName', 'lastName']
 });
 
-Joi.validate({firstName: 'John', lastName: 'Doe', age: 45}, schema, function (error, value) {
-    error && console.log(error);
-});
+const { error, value } = schema.validate({firstName: 'John', lastName: 'Doe', age: 45});
 ```
 
 ### Sub Schemas

--- a/index.js
+++ b/index.js
@@ -15,11 +15,11 @@ const optionsSchema = Joi.object({
 });
 
 const validate = function (schema, options = {}) {
-    const validateOptions = Joi.validate(options, optionsSchema);
+    const validateOptions = optionsSchema.validate(options);
 
     Hoek.assert(!validateOptions.error, validateOptions.error);
 
-    const validateSchema = Joi.validate(schema, schemaSchema);
+    const validateSchema = schemaSchema.validate(schema);
 
     Hoek.assert(!validateSchema.error, validateSchema.error);
 

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -19,13 +19,10 @@ class SchemaResolver {
                     items: Joi.array().items(Joi.object()).required()
                 },
                 validate(params, value, state, options) {
-                    let error;
                     options = Hoek.applyToDefaults(options, { allowUnknown: true });
 
                     for (const schema of params.items) {
-                        Joi.validate(value, schema, options, (err) => {
-                            error = err;
-                        });
+                        const { error } = schema.validate(value, options);
                         if (error) {
                             const details = error.details[0];
                             return this.createOverrideError(details.type, details.context, { path : details.path }, options, details.message);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enjoi",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "license": "Apache 2.0",
   "description": "Converts json-schema to Joi schema.",
   "main": "./index.js",
@@ -43,7 +43,8 @@
     "vh",
     "nfstein",
     "dimichgh",
-    "yosheeck"
+    "yosheeck",
+    "joescho"
   ],
   "bugs": {
     "url": "https://github.com/tlivings/enjoi/issues"

--- a/test/test-directives.js
+++ b/test/test-directives.js
@@ -1,7 +1,6 @@
 
 const Test = require('tape');
 const Enjoi = require('../index');
-const Joi = require('@hapi/joi');
 
 Test('directives', function (t) {
     t.test('anyOf', function (t) {
@@ -18,17 +17,11 @@ Test('directives', function (t) {
             ]
         });
 
-        Joi.validate('string', schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate('string').error, 'no error.');
 
-        Joi.validate(10, schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate(10).error, 'no error.');
 
-        Joi.validate({}, schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate({}).error, 'error.');
     });
 
     t.test('oneOf', function (t) {
@@ -55,41 +48,23 @@ Test('directives', function (t) {
             ]
         });
 
-        Joi.validate({ a: 'string' }, schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate({ a: 'string' }).error, 'no error.');
 
-        Joi.validate({}, schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate({}).error, 'no error.');
 
-        Joi.validate(undefined, schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate(undefined).error, 'no error.');
 
-        Joi.validate({ b: 10 }, schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate({ b: 10 }).error, 'no error.');
 
-        Joi.validate({ a: 'string', b: 10 }, schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate({ a: 'string', b: 10 }).error, 'error.');
 
-        Joi.validate({ a: 'string', b: null }, schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate({ a: 'string', b: null }).error, 'error.');
 
-        Joi.validate({ a: null, b: 10 }, schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate({ a: null, b: 10 }).error, 'error.');
 
-        Joi.validate({ a: null, b: null }, schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate({ a: null, b: null }).error, 'error.');
 
-        Joi.validate({ a: 'string', b: 'string' }, schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate({ a: 'string', b: 'string' }).error, 'error.');
     });
 
     t.test('not', function (t) {
@@ -116,37 +91,21 @@ Test('directives', function (t) {
             ]
         });
 
-        Joi.validate({ a: 'string' }, schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate({ a: 'string' }).error, 'error.');
 
-        Joi.validate({}, schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate({}).error, 'error.');
 
-        Joi.validate({ b: 10 }, schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate({ b: 10 }).error, 'error.');
 
-        Joi.validate({ a: 'string', b: 10 }, schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate({ a: 'string', b: 10 }).error, 'no error.');
 
-        Joi.validate({ a: 'string', b: null }, schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate({ a: 'string', b: null }).error, 'no error.');
 
-        Joi.validate({ a: null, b: 10 }, schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate({ a: null, b: 10 }).error, 'no error.');
 
-        Joi.validate({ a: null, b: null }, schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate({ a: null, b: null }).error, 'no error.');
 
-        Joi.validate({ a: 'string', b: 'string' }, schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate({ a: 'string', b: 'string' }).error, 'no error.');
     });
 
     t.test('additionalProperties boolean', function (t) {
@@ -161,23 +120,15 @@ Test('directives', function (t) {
             }
         };
 
-        Enjoi.schema(schema).validate({ file: 'data', consumes: 'application/json' }, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(Enjoi.schema(schema).validate({ file: 'data', consumes: 'application/json' }).error, 'error.');
 
         schema.additionalProperties = false;
-        Enjoi.schema(schema).validate({ file: 'data', consumes: 'application/json' }, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(Enjoi.schema(schema).validate({ file: 'data', consumes: 'application/json' }).error, 'error.');
 
         schema.additionalProperties = true;
-        Enjoi.schema(schema).validate({ file: 'data', consumes: 'application/json' }, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!Enjoi.schema(schema).validate({ file: 'data', consumes: 'application/json' }).error, 'no error.');
 
-        Enjoi.schema(schema).validate({ file: 5, consumes: 'application/json' }, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(Enjoi.schema(schema).validate({ file: 5, consumes: 'application/json' }).error, 'error.');
     });
 
     t.test('default values', function (t) {
@@ -210,12 +161,11 @@ Test('directives', function (t) {
             required: ['user']
         };
 
-        Enjoi.schema(schema).validate({ user: 'test@domain.tld' }, function (error, value) {
-            t.ok(!error, 'error');
-            t.equal(value.locale, 'en-US');
-            t.equal(value.isSubscribed, false);
-            t.equal(value.posts, 0);
-        });
+        const { error, value } = Enjoi.schema(schema).validate({ user: 'test@domain.tld' });
+        t.ok(!error, 'error');
+        t.equal(value.locale, 'en-US');
+        t.equal(value.isSubscribed, false);
+        t.equal(value.posts, 0);
     });
 
     t.test('additionalProperties false should not allow additional properties', function (t) {
@@ -224,23 +174,21 @@ Test('directives', function (t) {
         const schema = Enjoi.schema({
             type: 'file'
         },
-        {
-            types: {
-                file: Enjoi.schema({
-                    type: 'object',
-                    additionalProperties: false,
-                    properties: {
-                        file: {
-                            type: 'string'
+            {
+                types: {
+                    file: Enjoi.schema({
+                        type: 'object',
+                        additionalProperties: false,
+                        properties: {
+                            file: {
+                                type: 'string'
+                            }
                         }
-                    }
-                })
-            }
-        });
+                    })
+                }
+            });
 
-        schema.validate({ file: 'data', consumes: 'application/json' }, function (error, value) {
-            t.ok(error);
-        });
+        t.ok(schema.validate({ file: 'data', consumes: 'application/json' }).error);
     });
 
     t.test('additionalProperties true should allow additional properties', function (t) {
@@ -249,23 +197,21 @@ Test('directives', function (t) {
         const schema = Enjoi.schema({
             type: 'file'
         },
-        {
-            types: {
-                file: Enjoi.schema({
-                    type: 'object',
-                    additionalProperties: true,
-                    properties: {
-                        file: {
-                            type: 'string'
+            {
+                types: {
+                    file: Enjoi.schema({
+                        type: 'object',
+                        additionalProperties: true,
+                        properties: {
+                            file: {
+                                type: 'string'
+                            }
                         }
-                    }
-                })
-            }
-        });
+                    })
+                }
+            });
 
-        schema.validate({ file: 'data', consumes: 'application/json' }, function (error, value) {
-            t.ok(!error);
-        });
+        t.ok(!schema.validate({ file: 'data', consumes: 'application/json' }).error);
     });
 
     t.test('additionalProperties true should not affect validation of properties', function (t) {
@@ -274,23 +220,21 @@ Test('directives', function (t) {
         const schema = Enjoi.schema({
             type: 'file'
         },
-        {
-            types: {
-                file: Enjoi.schema({
-                    type: 'object',
-                    additionalProperties: true,
-                    properties: {
-                        file: {
-                            type: 'string'
+            {
+                types: {
+                    file: Enjoi.schema({
+                        type: 'object',
+                        additionalProperties: true,
+                        properties: {
+                            file: {
+                                type: 'string'
+                            }
                         }
-                    }
-                })
-            }
-        });
+                    })
+                }
+            });
 
-        schema.validate({ file: 5, consumes: 'application/json' }, function (error, value) {
-            t.ok(error);
-        });
+        t.ok(schema.validate({ file: 5, consumes: 'application/json' }).error);
     });
 
     t.test('additionalProperties object should not affect validation of properties', function (t) {
@@ -299,25 +243,23 @@ Test('directives', function (t) {
         const schema = Enjoi.schema({
             type: 'file'
         },
-        {
-            types: {
-                file: Enjoi.schema({
-                    type: 'object',
-                    additionalProperties: {
-                        type: 'string'
-                    },
-                    properties: {
-                        file: {
+            {
+                types: {
+                    file: Enjoi.schema({
+                        type: 'object',
+                        additionalProperties: {
                             type: 'string'
+                        },
+                        properties: {
+                            file: {
+                                type: 'string'
+                            }
                         }
-                    }
-                })
-            }
-        });
+                    })
+                }
+            });
 
-        schema.validate({ file: 'asdf', consumes: 'application/json' }, function (error, value) {
-            t.ok(!error);
-        });
+        t.ok(!schema.validate({ file: 'asdf', consumes: 'application/json' }).error);
     });
 
     t.test('additionalProperties object should add to validated properties', function (t) {
@@ -326,25 +268,23 @@ Test('directives', function (t) {
         const schema = Enjoi.schema({
             type: 'file'
         },
-        {
-            types: {
-                file: Enjoi.schema({
-                    type: 'object',
-                    additionalProperties: {
-                        type: 'string'
-                    },
-                    properties: {
-                        file: {
+            {
+                types: {
+                    file: Enjoi.schema({
+                        type: 'object',
+                        additionalProperties: {
                             type: 'string'
+                        },
+                        properties: {
+                            file: {
+                                type: 'string'
+                            }
                         }
-                    }
-                })
-            }
-        });
+                    })
+                }
+            });
 
-        schema.validate({ file: 'asdf', consumes: 5 }, function (error, value) {
-            t.ok(error);
-        });
+        t.ok(schema.validate({ file: 'asdf', consumes: 5 }).error);
     });
 
     t.test('array additionalItems', function (t) {
@@ -363,18 +303,11 @@ Test('directives', function (t) {
             additionalItems: false
         });
 
-        Joi.validate(['test'], schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate(['test']).error, 'no error.');
 
-        Joi.validate(['test', 123], schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate(['test', 123]).error, 'no error.');
 
-        Joi.validate(['test', 123, 'foo'], schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
-
+        t.ok(schema.validate(['test', 123, 'foo']).error, 'error.');
     });
 });
 
@@ -395,13 +328,9 @@ Test('allOf', function (t) {
             ]
         });
 
-        Joi.validate('abc', schema, function (error) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate('abc').error, 'no error.');
 
-        Joi.validate('abcd', schema, function (error) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate('abcd').error, 'error.');
     });
 
     t.test('allOf object', function (t) {
@@ -428,14 +357,11 @@ Test('allOf', function (t) {
             ]
         });
 
-        Joi.validate({ a: 'string', b: 10 }, schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate({ a: 'string', b: 10 }).error, 'no error.');
 
-        Joi.validate({ a: 'string', b: 'string' }, schema, function (error, value) {
-            t.ok(error, 'error.');
-            t.equal(error.details[0].message, '\"b\" must be a number');
-        });
+        const { error } = schema.validate({ a: 'string', b: 'string' });
+        t.ok(error, 'error.');
+        t.equal(error.details[0].message, '\"b\" must be a number');
     });
 
     t.test('allOf array with conflicting needs', function (t) {
@@ -463,9 +389,7 @@ Test('allOf', function (t) {
             ]
         });
 
-        Joi.validate([ 'string', 10 ], schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate(['string', 10]).error, 'error.');
     });
 
     t.test('allOf nested', function (t) {
@@ -496,13 +420,8 @@ Test('allOf', function (t) {
             ]
         });
 
-        Joi.validate({ name: 'test', phoneCountryCode: 'US' }, schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate({ name: 'test', phoneCountryCode: 'US' }).error, 'no error.');
 
-        Joi.validate({ name: 'test' }, schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate({ name: 'test' }).error, 'error.');
     });
-    
 });

--- a/test/test-enjoi.js
+++ b/test/test-enjoi.js
@@ -41,25 +41,15 @@ Test('enjoi', function (t) {
         t.equal(schema._description, 'An example to test against.', 'description set.');
         t.equal(schema._inner.children.length, 4, '4 properties defined.');
 
-        Joi.validate({ firstName: 'John', lastName: 'Doe', age: 45, tags: ['man', 'human'] }, schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate({ firstName: 'John', lastName: 'Doe', age: 45, tags: ['man', 'human'] }).error, 'no error.');
 
-        Joi.validate({ firstName: '', lastName: 'Doe', age: 45, tags: ['man', 'human'] }, schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate({ firstName: '', lastName: 'Doe', age: 45, tags: ['man', 'human'] }).error, 'no error.');
 
-        Joi.validate({ firstName: 'John', age: 45, tags: ['man', 'human'] }, schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate({ firstName: 'John', age: 45, tags: ['man', 'human'] }).error, 'error.');
 
-        Joi.validate({ firstName: 'John', lastName: 'Doe', age: 45, tags: [1, 'human'] }, schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate({ firstName: 'John', lastName: 'Doe', age: 45, tags: [1, 'human'] }).error, 'error.');
 
-        Joi.validate({ firstName: 'John', lastName: 'Doe', age: 45, tags: ['', 'human'] }, schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate({ firstName: 'John', lastName: 'Doe', age: 45, tags: ['', 'human'] }).error, 'error.');
     });
 
     t.test('with ref', function (t) {
@@ -80,9 +70,7 @@ Test('enjoi', function (t) {
             }
         });
 
-        Joi.validate({ name: 'Joe' }, schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate({ name: 'Joe' }).error, 'no error.');
     });
 
 });
@@ -102,9 +90,7 @@ Test('enjoi defaults', function (t) {
             type: 'test'
         });
 
-        Joi.validate('string', schema, function (error) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate('string').error, 'no error.');
     });
 
     t.test('overrides', function (t) {
@@ -124,9 +110,7 @@ Test('enjoi defaults', function (t) {
             }
         });
 
-        Joi.validate('string', schema, function (error) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate('string').error, 'error.');
     });
 
     t.test('overrides extensions', function (t) {
@@ -178,13 +162,8 @@ Test('enjoi defaults', function (t) {
             }
         });
 
-        Joi.validate('foobar', enjoi.schema({ type: 'foo' }), function (error) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!enjoi.schema({ type: 'foo' }).validate('foobar').error, 'no error.');
 
-        Joi.validate('foobaz', schema, function (error) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate('foobaz').error, 'no error.');
     });
-
 });

--- a/test/test-options.js
+++ b/test/test-options.js
@@ -14,11 +14,11 @@ Test('options features', function (t) {
         }, {
             refineType(type, format) {
                 switch (type) {
-                    case 'string': {
+                    case 'string':
                         if (format === 'binary') {
                             return 'binary'
                         }
-                    }
+                        break;
                     default:
                         return type;
                 }
@@ -28,10 +28,9 @@ Test('options features', function (t) {
             }
         });
 
-        Joi.validate('aGVsbG8=', schema, function (error, value) {
-            t.ok(!error, 'no error.');
-            t.equal(value.toString(), 'hello');
-        });
+        const { error, value } = schema.validate('aGVsbG8=');
+        t.ok(!error, 'no error.');
+        t.equal(value.toString(), 'hello');
     });
 
     t.test('custom type', function (t) {
@@ -40,18 +39,14 @@ Test('options features', function (t) {
         const schema = Enjoi.schema({
             type: 'custom'
         }, {
-                types: {
-                    custom: Joi.string()
-                }
-            });
-
-        Joi.validate('string', schema, function (error, value) {
-            t.ok(!error, 'no error.');
+            types: {
+                custom: Joi.string()
+            }
         });
 
-        Joi.validate(10, schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(!schema.validate('string').error, 'no error.');
+
+        t.ok(schema.validate(10).error, 'error.');
     });
 
     t.test('type function', function (t) {
@@ -68,9 +63,7 @@ Test('options features', function (t) {
             }
         });
 
-        Joi.validate('example', schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate('example').error, 'no error.');
     });
 
     t.test('custom complex type', function (t) {
@@ -95,13 +88,9 @@ Test('options features', function (t) {
             }
         });
 
-        schema.validate({ file: 'data', consumes: 'multipart/form-data' }, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate({ file: 'data', consumes: 'multipart/form-data' }).error, 'no error.');
 
-        schema.validate({ file: 'data', consumes: 'application/json' }, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate({ file: 'data', consumes: 'application/json' }).error, 'error.');
     });
 
     t.test('with external ref', function (t) {
@@ -125,9 +114,7 @@ Test('options features', function (t) {
             }
         });
 
-        Joi.validate({ name: 'Joe' }, schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate({ name: 'Joe' }).error, 'no error.');
     });
 
     t.test('with both inline and external refs', function (t) {
@@ -159,9 +146,7 @@ Test('options features', function (t) {
             }
         });
 
-        Joi.validate({ firstname: 'Joe', surname: 'Doe' }, schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate({ firstname: 'Joe', surname: 'Doe' }).error, 'no error.');
     });
 
 });
@@ -193,11 +178,7 @@ Test('extensions', function (t) {
         }
     });
 
-    Joi.validate('foobar', schema, function (error, value) {
-        t.ok(!error, 'no error.');
-    });
+    t.ok(!schema.validate('foobar').error, 'no error.');
 
-    Joi.validate('foo', schema, function (error, value) {
-        t.ok(error, 'error.');
-    });
+    t.ok(schema.validate('foo').error, 'error.');
 });

--- a/test/test-types.js
+++ b/test/test-types.js
@@ -1,7 +1,6 @@
 
 const Test = require('tape');
 const Enjoi = require('../index');
-const Joi = require('@hapi/joi');
 
 Test('types', function (t) {
 
@@ -14,17 +13,11 @@ Test('types', function (t) {
             'minProperties': 1
         });
 
-        Joi.validate({ a: 'a', b: 'b' }, schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate({ a: 'a', b: 'b' }).error, 'no error.');
 
-        Joi.validate({ a: 'a', b: 'b', c: 'c' }, schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate({ a: 'a', b: 'b', c: 'c' }).error, 'error.');
 
-        Joi.validate({}, schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate({}).error, 'error.');
     });
 
     t.test('arrays and numbers', function (t) {
@@ -39,13 +32,9 @@ Test('types', function (t) {
             'minItems': 0
         });
 
-        Joi.validate([1, 2], schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate([1, 2]).error, 'no error.');
 
-        Joi.validate([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]).error, 'error.');
     });
 
     t.test('arrays with specific item type assignment', function (t) {
@@ -62,33 +51,19 @@ Test('types', function (t) {
             ],
         });
 
-        Joi.validate([1, 'abc'], schema, function (error) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate([1, 'abc']).error, 'no error.');
 
-        Joi.validate([0, 1], schema, function (error) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate([0, 1]).error, 'no error.');
 
-        Joi.validate(['abc', 'def'], schema, function (error) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate(['abc', 'def']).error, 'no error.');
 
-        Joi.validate([1], schema, function (error) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate([1]).error, 'no error.');
 
-        Joi.validate(['abc'], schema, function (error) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate(['abc']).error, 'no error.');
 
-        Joi.validate([], schema, function (error) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate([]).error, 'no error.');
 
-        Joi.validate([{ foo: 'bar' }], schema, function (error) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate([{ foo: 'bar' }]).error, 'error.');
     });
 
     t.test('arrays with ordered item assignment', function (t) {
@@ -105,37 +80,21 @@ Test('types', function (t) {
             ],
         });
 
-        Joi.validate([1, 'abc'], schema, function (error) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate([1, 'abc']).error, 'no error.');
 
-        Joi.validate([], schema, function (error) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate([]).error, 'no error.');
 
-        Joi.validate([0, 1], schema, function (error) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate([0, 1]).error, 'error.');
 
-        Joi.validate(['abc', 'def'], schema, function (error) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate(['abc', 'def']).error, 'error.');
 
-        Joi.validate([1], schema, function (error) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate([1]).error, 'no error.');
 
-        Joi.validate(['abc'], schema, function (error) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate(['abc']).error, 'error.');
 
-        Joi.validate([{ foo: 'bar' }], schema, function (error) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate([{ foo: 'bar' }]).error, 'error.');
 
-        Joi.validate([1, 'abc', 'def'], schema, function (error) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate([1, 'abc', 'def']).error, 'error.');
     });
 
     t.test('arrays and refs', function (t) {
@@ -158,13 +117,9 @@ Test('types', function (t) {
             }
         });
 
-        Joi.validate([1, 2], schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate([1, 2]).error, 'no error.');
 
-        Joi.validate([1, 3], schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate([1, 3]).error, 'error.');
     });
 
     t.test('number exclusiveMinimum exclusiveMaximum', function (t) {
@@ -176,17 +131,11 @@ Test('types', function (t) {
             'exclusiveMaximum': 2,
         });
 
-        Joi.validate(0, schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate(0).error, 'error.');
 
-        Joi.validate(1, schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate(1).error, 'no error.');
 
-        Joi.validate(2, schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate(2).error, 'error.');
     });
 
     t.test('number multipleOf', function (t) {
@@ -197,17 +146,11 @@ Test('types', function (t) {
             'multipleOf': 1.5,
         });
 
-        Joi.validate(4, schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate(4).error, 'error.');
 
-        Joi.validate(4.5, schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate(4.5).error, 'no error.');
 
-        Joi.validate(0, schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate(0).error, 'no error.');
     });
 
     t.test('arrays and unique', function (t) {
@@ -221,13 +164,9 @@ Test('types', function (t) {
             'uniqueItems': true
         });
 
-        Joi.validate([1, 2], schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate([1, 2]).error, 'no error.');
 
-        Joi.validate([1, 1], schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate([1, 1]).error, 'error.');
     });
 
     t.test('boolean', function (t) {
@@ -237,17 +176,11 @@ Test('types', function (t) {
             'type': 'boolean'
         });
 
-        Joi.validate('1', schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate('1').error, 'error.');
 
-        Joi.validate('true', schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate('true').error, 'no error.');
 
-        Joi.validate(true, schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate(true).error, 'no error.');
     });
 
     t.test('boolean strictMode', function (t) {
@@ -259,17 +192,11 @@ Test('types', function (t) {
             strictMode: true
         });
 
-        Joi.validate('1', schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate('1').error, 'error.');
 
-        Joi.validate('true', schema, function (error, value) {
-            t.ok(error, 'error in strictMode.');
-        });
+        t.ok(schema.validate('true').error, 'error in strictMode.');
 
-        Joi.validate(true, schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate(true).error, 'no error.');
     });
 
     t.test('string regex', function (t) {
@@ -280,19 +207,13 @@ Test('types', function (t) {
             'pattern': /foobar/
         });
 
-        Joi.validate('foo', schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate('foo').error, 'error.');
 
-        Joi.validate('', schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate('').error, 'error.');
 
-        Joi.validate('foobar', schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate('foobar').error, 'no error.');
     });
-    
+
     t.test('string length', function (t) {
         t.plan(3);
 
@@ -302,17 +223,11 @@ Test('types', function (t) {
             'maxLength': 4
         });
 
-        Joi.validate('f', schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate('f').error, 'error.');
 
-        Joi.validate('foobar', schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate('foobar').error, 'error.');
 
-        Joi.validate('foo', schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate('foo').error, 'no error.');
     });
 
     t.test('string email', function (t) {
@@ -324,17 +239,11 @@ Test('types', function (t) {
             'maxLength': 20
         });
 
-        Joi.validate('', schema, function (error, value) {
-            t.ok(error, "empty string.");
-        });
+        t.ok(schema.validate('').error, "empty string.");
 
-        Joi.validate('wrongemail', schema, function (error, value) {
-            t.ok(error, "wrong email error.");
-        });
+        t.ok(schema.validate('wrongemail').error, "wrong email error.");
 
-        Joi.validate('right@email.com', schema, function (error, value) {
-            t.ok(!error, "good email.");
-        });
+        t.ok(!schema.validate('right@email.com').error, "good email.");
 
     });
 
@@ -360,16 +269,12 @@ Test('types', function (t) {
 
         // Valid values
         validDateValues.forEach((time) => {
-            Joi.validate(time, schema, function (error, value) {
-                t.ok(!error, time + ' should be valid');
-            });
+            t.ok(!schema.validate(time).error, time + ' should be valid');
         });
 
         // Invalid values
         invalidDateValues.forEach((time) => {
-            Joi.validate(time, schema, function (error, value) {
-                t.ok(error, time + ' should be invalid');
-            });
+            t.ok(schema.validate(time).error, time + ' should be invalid');
         });
     });
 
@@ -403,16 +308,12 @@ Test('types', function (t) {
 
         // Valid values
         validTimeValues.forEach((time) => {
-            Joi.validate(time, schema, function (error, value) {
-                t.ok(!error, time + ' should be valid');
-            });
+            t.ok(!schema.validate(time).error, time + ' should be valid');
         });
 
         // Invalid values
         invalidTimeValues.forEach((time) => {
-            Joi.validate(time, schema, function (error, value) {
-                t.ok(error, time + ' should be invalid');
-            });
+            t.ok(schema.validate(time).error, time + ' should be invalid');
         });
     });
 
@@ -444,16 +345,12 @@ Test('types', function (t) {
 
         // Valid values
         validDateTimeValues.forEach((time) => {
-            Joi.validate(time, schema, function (error, value) {
-                t.ok(!error, time + ' should be valid');
-            });
+            t.ok(!schema.validate(time).error, time + ' should be valid');
         });
 
         // Invalid values
         invalidDateTimeValues.forEach((time) => {
-            Joi.validate(time, schema, function (error, value) {
-                t.ok(error, time + ' should be invalid');
-            });
+            t.ok(schema.validate(time).error, time + ' should be invalid');
         });
     });
 
@@ -465,17 +362,11 @@ Test('types', function (t) {
             'format': 'hostname'
         });
 
-        Joi.validate('', schema, function (error, value) {
-            t.ok(error, "empty string.");
-        });
+        t.ok(schema.validate('').error, "empty string.");
 
-        Joi.validate('not@host', schema, function (error, value) {
-            t.ok(error, "bad host error.");
-        });
+        t.ok(schema.validate('not@host').error, "bad host error.");
 
-        Joi.validate('isahost.com', schema, function (error, value) {
-            t.ok(!error, "good host.");
-        });
+        t.ok(!schema.validate('isahost.com').error, "good host.");
 
     });
 
@@ -487,18 +378,11 @@ Test('types', function (t) {
             'format': 'ipv4'
         });
 
-        Joi.validate('', schema, function (error, value) {
-            t.ok(error, "empty string.");
-        });
+        t.ok(schema.validate('').error, "empty string.");
 
-        Joi.validate('asdf', schema, function (error, value) {
-            t.ok(error, "bad ipv4 error.");
-        });
+        t.ok(schema.validate('asdf').error, "bad ipv4 error.");
 
-        Joi.validate('127.0.0.1', schema, function (error, value) {
-            t.ok(!error, "good ipv4.");
-        });
-
+        t.ok(!schema.validate('127.0.0.1').error, "good ipv4.");
     });
 
     t.test('string ipv6', function (t) {
@@ -509,17 +393,11 @@ Test('types', function (t) {
             'format': 'ipv6'
         });
 
-        Joi.validate('', schema, function (error, value) {
-            t.ok(error, "empty string.");
-        });
-        
-        Joi.validate('asdf', schema, function (error, value) {
-            t.ok(error, "bad ipv6 error.");
-        });
+        t.ok(schema.validate('').error, "empty string.");
 
-        Joi.validate('::1', schema, function (error, value) {
-            t.ok(!error, "good ipv6.");
-        });
+        t.ok(schema.validate('asdf').error, "bad ipv6 error.");
+
+        t.ok(!schema.validate('::1').error, "good ipv6.");
 
     });
 
@@ -531,17 +409,11 @@ Test('types', function (t) {
             'format': 'uri'
         });
 
-        Joi.validate('', schema, function (error, value) {
-            t.ok(error, "empty string.");
-        });
-        
-        Joi.validate('asdf', schema, function (error, value) {
-            t.ok(error, "bad uri error.");
-        });
+        t.ok(schema.validate('').error, "empty string.");
 
-        Joi.validate('http://example.com', schema, function (error, value) {
-            t.ok(!error, "good uri.");
-        });
+        t.ok(schema.validate('asdf').error, "bad uri error.");
+
+        t.ok(!schema.validate('http://example.com').error, "good uri.");
 
     });
 
@@ -553,13 +425,9 @@ Test('types', function (t) {
             format: 'binary'
         });
 
-        Joi.validate(new Buffer('hello'), schema, function (error) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate(new Buffer('hello')).error, 'no error.');
 
-        Joi.validate([1, 2, 3, 4], schema, function (error) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate([1, 2, 3, 4]).error, 'error.');
     });
 
     t.test('string binary min/max', function (t) {
@@ -572,17 +440,11 @@ Test('types', function (t) {
             maxLength: 4
         });
 
-        Joi.validate(new Buffer('hello'), schema, function (error) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate(new Buffer('hello')).error, 'error.');
 
-        Joi.validate(new Buffer('h'), schema, function (error) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate(new Buffer('h')).error, 'error.');
 
-        Joi.validate(new Buffer('hell'), schema, function (error) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate(new Buffer('hell')).error, 'no error.');
     });
 
     t.test('string byte', function (t) {
@@ -593,13 +455,9 @@ Test('types', function (t) {
             format: 'byte'
         });
 
-        Joi.validate('U3dhZ2dlciByb2Nrcw==', schema, function (error) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate('U3dhZ2dlciByb2Nrcw==').error, 'no error.');
 
-        Joi.validate('hello', schema, function (error) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate('hello').error, 'error.');
     });
 
     t.test('string uuid', function (t) {
@@ -609,18 +467,12 @@ Test('types', function (t) {
             type: 'string',
             format: 'uuid'
         });
-        
-        Joi.validate('36c6e954-3c0a-4fbf-a4cd-6993ffe3bdd2', schema, function (error) {
-            t.ok(!error, 'no error.');
-        });
 
-        Joi.validate('', schema, function (error, value) {
-            t.ok(error, "empty string.");
-        });
-        
-        Joi.validate('not a uuid', schema, function (error) {
-            t.ok(error, 'error.');
-        });
+        t.ok(!schema.validate('36c6e954-3c0a-4fbf-a4cd-6993ffe3bdd2').error, 'no error.');
+
+        t.ok(schema.validate('').error, "empty string.");
+
+        t.ok(schema.validate('not a uuid').error, 'error.');
     });
 
     t.test('string guid', function (t) {
@@ -631,17 +483,11 @@ Test('types', function (t) {
             format: 'guid'
         });
 
-        Joi.validate('36c6e954-3c0a-4fbf-a4cd-6993ffe3bdd2', schema, function (error) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate('36c6e954-3c0a-4fbf-a4cd-6993ffe3bdd2').error, 'no error.');
 
-        Joi.validate('', schema, function (error, value) {
-            t.ok(error, "empty string.");
-        });
-        
-        Joi.validate('not a uuid', schema, function (error) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate('').error, "empty string.");
+
+        t.ok(schema.validate('not a uuid').error, 'error.');
     });
 
     t.test('no type, ref, or enum validates anything.', function (t) {
@@ -651,26 +497,18 @@ Test('types', function (t) {
             'description': 'something'
         });
 
-        Joi.validate('A', schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate('A').error, 'no error.');
 
-        Joi.validate({ 'A': 'a' }, schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate({ 'A': 'a' }).error, 'no error.');
 
-        Joi.validate([1, 2, 3], schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate([1, 2, 3]).error, 'no error.');
     });
 
     t.test('shorthand type', function (t) {
         t.plan(1);
 
         const schema = Enjoi.schema('string');
-        Joi.validate('A', schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate('A').error, 'no error.');
     });
 
 
@@ -684,9 +522,7 @@ Test('types', function (t) {
             }
         });
 
-        Joi.validate({ name: 'test' }, schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate({ name: 'test' }).error, 'no error.');
     });
 
     t.test('enum', function (t) {
@@ -696,30 +532,20 @@ Test('types', function (t) {
             'enum': ['A', 'B']
         });
 
-        Joi.validate('A', schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate('A').error, 'no error.');
 
-        Joi.validate('B', schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate('B').error, 'no error.');
 
-        Joi.validate('C', schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate('C').error, 'error.');
 
         schema = Enjoi.schema({
             type: 'string',
             'enum': ['A', 'B']
         });
 
-        Joi.validate('B', schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate('B').error, 'no error.');
 
-        Joi.validate('C', schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate('C').error, 'error.');
     });
 
     t.test('unknown type fails', function (t) {
@@ -739,17 +565,11 @@ Test('types', function (t) {
             'type': ['boolean', 'string']
         });
 
-        Joi.validate(10, schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate(10).error, 'error.');
 
-        Joi.validate(true, schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate(true).error, 'no error.');
 
-        Joi.validate('true', schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate('true').error, 'no error.');
     });
 
     t.test('array for type with null support', function (t) {
@@ -759,17 +579,11 @@ Test('types', function (t) {
             'type': ['string', 'null']
         });
 
-        Joi.validate('test', schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate('test').error, 'no error.');
 
-        Joi.validate(null, schema, function (error, value) {
-            t.ok(!error, 'no error.');
-        });
+        t.ok(!schema.validate(null).error, 'no error.');
 
-        Joi.validate(false, schema, function (error, value) {
-            t.ok(error, 'error.');
-        });
+        t.ok(schema.validate(false).error, 'error.');
     });
 
 });


### PR DESCRIPTION
Use schema.validate instead of Joi.validate

This fixes the issue when using enjoi:
```
TypeError: Joi.validate is not a function
at validate (<...my_path>\node_modules\enjoi\index.js:18:33)
```