### PR TITLE
Allow empty strings by default if the minLength field is not provided

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -351,7 +351,7 @@ class SchemaResolver {
         if (Util.isUndefined(schema.minLength)) {
             schema.minLength = 0;
         }
-        else if (schema.minLength === 0) {
+        if (schema.minLength === 0) {
             joischema = joischema.allow('');
         }
         Util.isNumber(schema.minLength) && (joischema = joischema.min(schema.minLength));


### PR DESCRIPTION
I don't want to provide the field everywhere. This line of code makes me cry when I use a very expensive schema