### PR TITLE
Add refineSchema function option, allow '' for functions without pattern or format

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Please file issues for other unsupported features.
 
 - `subSchemas` - an (optional) object with keys representing schema ids, and values representing schemas.
 - `refineType(type, format)` - an (optional) function to call to apply to type based on the type and format of the JSON schema.
+- `refineSchema(joiSchema, jsonSchema)` - an (optional) function to call to apply to adjust Joi schema base on the original JSON schema. Primary use case is handling `nullability` flag in OpenAPI 3.0
 - `extensions` - an array of extensions to pass [joi.extend](https://github.com/hapijs/joi/blob/master/API.md#extendextension).
 - `strictMode` - make schemas `strict(value)` with a default value of `false`.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Please file issues for other unsupported features.
 
 - `subSchemas` - an (optional) object with keys representing schema ids, and values representing schemas.
 - `refineType(type, format)` - an (optional) function to call to apply to type based on the type and format of the JSON schema.
-- `refineSchema(joiSchema, jsonSchema)` - an (optional) function to call to apply to adjust Joi schema base on the original JSON schema. Primary use case is handling `nullability` flag in OpenAPI 3.0
+- `refineSchema(joiSchema, jsonSchema)` - an (optional) function to call to apply to adjust Joi schema base on the original JSON schema. Primary use case is handling `nullable` flag in OpenAPI 3.0
 - `extensions` - an array of extensions to pass [joi.extend](https://github.com/hapijs/joi/blob/master/API.md#extendextension).
 - `strictMode` - make schemas `strict(value)` with a default value of `false`.
 

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const optionsSchema = Joi.object({
     subSchemas: Joi.object().unknown(true).allow(null),
     extensions: Joi.array().items(Joi.object().unknown(true)).allow(null),
     refineType: Joi.func().allow(null),
+    refineSchema: Joi.func().allow(null),
     strictMode: Joi.boolean().default(false),
 });
 
@@ -31,6 +32,7 @@ exports.defaults = function (defaults = {}) {
                 subSchemas: Object.assign({}, defaults.subSchemas, options.subSchemas),
                 extensions: defaults.extensions || [],
                 refineType: options.refineType || defaults.refineType,
+                refineSchema: options.refineSchema || defaults.refineSchema,
                 strictMode: options.strictMode || defaults.strictMode
             };
             if (Util.isArray(options.extensions)) {

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -344,8 +344,10 @@ class SchemaResolver {
 
         if (Util.isUndefined(schema.minLength)) {
             schema.minLength = 0;
-        }
-        else if (schema.minLength === 0) {
+            if (!schema.pattern && !schema.format) {
+                joischema = joischema.allow('');
+            }
+        } else if (schema.minLength === 0) {
             joischema = joischema.allow('');
         }
         Util.isNumber(schema.minLength) && (joischema = joischema.min(schema.minLength));

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -4,10 +4,11 @@ const Hoek = require('@hapi/hoek');
 const Bourne = require('@hapi/bourne');
 
 class SchemaResolver {
-    constructor(root, { subSchemas, refineType, strictMode, extensions = [] }) {
+    constructor(root, { subSchemas, refineType, refineSchema, strictMode, extensions = [] }) {
         this.root = root;
         this.subSchemas = subSchemas;
         this.refineType = refineType;
+        this.refineSchema = refineSchema;
         this.strictMode = strictMode;
 
         this.joi = Joi.extend(
@@ -47,45 +48,38 @@ class SchemaResolver {
     }
 
     resolve(schema = this.root) {
+        let resolvedSchema;
         if (schema.type) {
-            return this.resolveType(schema);
+            resolvedSchema =this.resolveType(schema);
+        } else if (schema.anyOf) {
+            resolvedSchema = this.resolveAnyOf(schema);
+        } else if (schema.allOf) {
+            resolvedSchema = this.resolveAllOf(schema);
+        } else if (schema.oneOf) {
+            resolvedSchema = this.resolveOneOf(schema);
+        } else if (schema.not) {
+            resolvedSchema = this.resolveNot(schema);
+        } else if (schema.$ref) {
+            resolvedSchema = this.resolve(this.resolveReference(schema.$ref));
+        } else if (schema.enum) {
+            // If no type is specified, just enum
+            resolvedSchema = this.joi.any().valid(...schema.enum);
+        } else if (typeof schema === 'string') {
+            // If schema is itself a string, interpret it as a type
+            resolvedSchema = this.resolveType({ type: schema });
+        } else {
+            //Fall through to whatever.
+            //eslint-disable-next-line no-console
+            console.warn('WARNING: schema missing a \'type\' or \'$ref\' or \'enum\': \n%s', JSON.stringify(schema, null, 2));
+            //TODO: Handle better
+            resolvedSchema = this.joi.any();
         }
 
-        if (schema.anyOf) {
-            return this.resolveAnyOf(schema);
+        if (this.refineSchema) {
+            resolvedSchema = this.refineSchema(resolvedSchema, schema);
         }
 
-        if (schema.allOf) {
-            return this.resolveAllOf(schema);
-        }
-
-        if (schema.oneOf) {
-            return this.resolveOneOf(schema);
-        }
-
-        if (schema.not) {
-            return this.resolveNot(schema);
-        }
-
-        if (schema.$ref) {
-            return this.resolve(this.resolveReference(schema.$ref));
-        }
-
-        //if no type is specified, just enum
-        if (schema.enum) {
-            return this.joi.any().valid(...schema.enum);
-        }
-
-        // If schema is itself a string, interpret it as a type
-        if (typeof schema === 'string') {
-            return this.resolveType({ type: schema });
-        }
-
-        //Fall through to whatever.
-        //eslint-disable-next-line no-console
-        console.warn('WARNING: schema missing a \'type\' or \'$ref\' or \'enum\': \n%s', JSON.stringify(schema, null, 2));
-        //TODO: Handle better
-        return this.joi.any();
+        return(resolvedSchema);
     }
 
     resolveReference(value) {

--- a/test/test-options.js
+++ b/test/test-options.js
@@ -251,5 +251,34 @@ Test('extensions', function (t) {
         t.ok(schema.validate('root@example.org').error);
         t.ok(!schema.validate('test@example.com').error);
         t.ok(schema.validate('foobar').error);
-    })   
+    })
+    
+    t.test('refineSchema', function (t) {
+        t.plan(3);
+
+        const schema = Enjoi.schema({
+            type: 'object',
+            properties: {
+                x: {
+                    type: 'string',
+                    nullability: 'true'
+                }
+            }
+        }, {
+            extensions: [{
+                type: 'email',
+                base: Joi.string().email()
+            }],
+            refineSchema(joiSchema, jsonSchema) {
+                if (jsonSchema.nullability) {
+                    return joiSchema.allow(null);
+                }
+                return joiSchema;
+            }
+        });
+
+        t.ok(!schema.validate({x: null}).error);
+        t.ok(!schema.validate({x: 'foobar'}).error);
+        t.ok(schema.validate({x: 123}).error);
+    }) 
 });

--- a/test/test-options.js
+++ b/test/test-options.js
@@ -261,7 +261,7 @@ Test('extensions', function (t) {
             properties: {
                 x: {
                     type: 'string',
-                    nullability: 'true'
+                    nullable: 'true'
                 }
             }
         }, {
@@ -270,7 +270,7 @@ Test('extensions', function (t) {
                 base: Joi.string().email()
             }],
             refineSchema(joiSchema, jsonSchema) {
-                if (jsonSchema.nullability) {
+                if (jsonSchema.nullable) {
                     return joiSchema.allow(null);
                 }
                 return joiSchema;

--- a/test/test-types.js
+++ b/test/test-types.js
@@ -381,7 +381,7 @@ Test('types', function (t) {
             format: 'binary'
         });
 
-        t.ok(!schema.validate(new Buffer('hello')).error, 'no error.');
+        t.ok(!schema.validate(new Buffer.from('hello')).error, 'no error.');
         t.ok(schema.validate([1, 2, 3, 4]).error, 'error.');
     });
 
@@ -395,9 +395,9 @@ Test('types', function (t) {
             maxLength: 4
         });
 
-        t.ok(schema.validate(new Buffer('hello')).error, 'error.');
-        t.ok(schema.validate(new Buffer('h')).error, 'error.');
-        t.ok(!schema.validate(new Buffer('hell')).error, 'no error.');
+        t.ok(schema.validate(new Buffer.from('hello')).error, 'error.');
+        t.ok(schema.validate(new Buffer.from('h')).error, 'error.');
+        t.ok(!schema.validate(new Buffer.from('hell')).error, 'no error.');
     });
 
     t.test('string byte', function (t) {
@@ -436,6 +436,17 @@ Test('types', function (t) {
         t.ok(!schema.validate('36c6e954-3c0a-4fbf-a4cd-6993ffe3bdd2').error, 'no error.');
         t.ok(schema.validate('').error, 'empty string.');
         t.ok(schema.validate('not a uuid').error, 'error.');
+    });
+
+    t.test('empty string', function (t) {
+        t.plan(2);
+
+        const schema = Enjoi.schema({
+            type: 'string'
+        });
+
+        t.ok(!schema.validate('foobar').error, 'no error.');
+        t.ok(!schema.validate('').error, 'no error');
     });
 
     t.test('no type, ref, or enum validates anything.', function (t) {


### PR DESCRIPTION
This pull request adds `refineSchema` a new function option for enjoi. It is necessary to support `nullable` schema modifier in OpenAPI 3.0

In addition string type without pattern or format modifier now validates empty string as specified by JSON schema:https://json-schema.org/understanding-json-schema/reference/string.html