### PR TITLE
feature: allow unique keys on array schema

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -269,9 +269,20 @@ class SchemaResolver {
 
         Util.isNumber(schema.minItems) && (joischema = joischema.min(schema.minItems));
         Util.isNumber(schema.maxItems) && (joischema = joischema.max(schema.maxItems));
-
+        
         if (schema.uniqueItems) {
             joischema = joischema.unique();
+        }
+        else if (schema.uniques) {
+            const uniques = schema.uniques;
+            joischema = joischema.unique((a, b) => {
+                let same = 0;
+                for (let i = 0; i < schema.uniques.length; i++) {
+                    if(a[uniques[i]] === b[uniques[i]])
+                        same++;
+                }
+                return same === uniques.length;
+            });
         }
 
         return joischema;


### PR DESCRIPTION
I'm adding a new unique behavior.

The main reason is that i need unique values on certain properties of array items.

Example:
I have an array of objects and need uniques elements by "key1", "key2", "key3"

Valid schema
```
[
{key1: "200-300", key2: "wishlist_1", key3: "bid1.", indicator: true},
{key1: "200-300", key2: "wishlist_2", key3: "bid1.", indicator: false},
{key1: "200-300", key2: "wishlist_3", key3: "bid1.", indicator: true},
]
```

Invalid schema. Has duplicates values for keys ("key1", "key2", "key3")
```
[
{key1: "200-300", key2: "wishlist_1", key3: "bid1.", indicator: true},
{key1: "200-300", key2: "wishlist_1", key3: "bid1.", indicator: false},
{key1: "200-300", key2: "wishlist_3", key3: "bid1.", indicator: true},
]
```