### PR TITLE
allow extension constructors

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,10 +4,11 @@ const Util = require('util');
 const SchemaResolver = require('./lib/resolver');
 
 const schemaSchema = Joi.alternatives(Joi.object().unknown(true), Joi.string()).required();
+const extensionSchema = Joi.alternatives().try(Joi.object().unknown(true), Joi.function())
 
 const optionsSchema = Joi.object({
     subSchemas: Joi.object().unknown(true).allow(null),
-    extensions: Joi.array().items(Joi.object().unknown(true)).allow(null),
+    extensions: Joi.array().items(extensionSchema).allow(null),
     refineType: Joi.func().allow(null),
     refineSchema: Joi.func().allow(null),
     strictMode: Joi.boolean().default(false),

--- a/test/test-enjoi.js
+++ b/test/test-enjoi.js
@@ -119,9 +119,9 @@ Test('enjoi extensions', function (t) {
 
         const enjoi = Enjoi.defaults({
             extensions: [
-                {
+                (joi) => ({
                     type: 'special',
-                    base: Joi.string(),
+                    base: joi.string(),
                     rules: {
                         hello: {
                             validate(value, helpers, args, options) {
@@ -137,7 +137,7 @@ Test('enjoi extensions', function (t) {
                     messages: {
                         'special.hello': '{{#label}} must say hello'
                     }
-                }
+                })
             ]
         });
 


### PR DESCRIPTION
While using Enjoi (latest) recently I ran into a bug. Joi (17.3.0) [modifies passed extension rule objects so they include the `argsByName` key](https://github.com/sideway/joi/blob/9cffab90039c313ca62d473d01993b492dd4d007/lib/extend.js#L111), however this additional key means they no longer are valid extension objects. 

Due to this, passing the same set of extensions (must include an extension with rule arguments) to Enjoi will fail with a validation error during the second usage.

Opened an issue for this here: https://github.com/sideway/joi/issues/2514

The easiest way to avoid this is to pass extension constructor functions that return a new instance of the extension each time rather than passing a reused set of objects. However Enjoi's validation required this change to allow extension constructor functions.