### PR TITLE
keep string enum type

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -301,7 +301,7 @@ class SchemaResolver {
         const dateTimeRegex = dateRegex + 'T' + timeRegex;
 
         if (schema.enum) {
-            return this.joi.any().valid(...schema.enum);
+            return this.joi.string().valid(...schema.enum);
         }
 
         switch (schema.format) {

--- a/test/test-types.js
+++ b/test/test-types.js
@@ -483,7 +483,7 @@ Test('types', function (t) {
     });
 
     t.test('enum', function (t) {
-        t.plan(5);
+        t.plan(7);
 
         let schema = Enjoi.schema({
             'enum': ['A', 'B']
@@ -500,6 +500,14 @@ Test('types', function (t) {
 
         t.ok(!schema.validate('B').error, 'no error.');
         t.ok(schema.validate('C').error, 'error.');
+
+        schema = Enjoi.schema({
+            type: 'string',
+            enum: ['A', 'B']
+        }).insensitive()
+
+        t.ok(!schema.validate('b').error, 'no error.');
+        t.ok(schema.validate('c').error, 'error.');
     });
 
     t.test('unknown type fails', function (t) {


### PR DESCRIPTION
when detecting an enum with `type: string` the joi validator returned by enjoi is built off the `any` type instead of `string`.

this prevents use of some string specific functionality in joi, like case insensitive comparisons against the enum.

this modification makes enjoi return a joi string-typed enum instead.