### PR TITLE
allow allOf/anyOf/oneOf to be combined with a base schema

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -62,6 +62,9 @@ class SchemaResolver {
             } else if (schema.properties) {
                 // if no type is specified, just properties
                 partialSchemas.push(this.object(schema))
+            } else if (schema.format) {
+                // if no type is specified, just format
+                partialSchemas.push(this.string(schema))
             } else if (schema.enum) {
                 // If no type is specified, just enum
                 partialSchemas.push(this.joi.any().valid(...schema.enum));

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -59,6 +59,9 @@ class SchemaResolver {
             const partialSchemas = [];
             if (schema.type) {
                 partialSchemas.push(this.resolveType(schema));
+            } else if (schema.properties) {
+                // if no type is specified, just properties
+                partialSchemas.push(this.object(schema))
             } else if (schema.enum) {
                 // If no type is specified, just enum
                 partialSchemas.push(this.joi.any().valid(...schema.enum));

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -49,37 +49,47 @@ class SchemaResolver {
 
     resolve(schema = this.root) {
         let resolvedSchema;
-        if (schema.type) {
-            resolvedSchema =this.resolveType(schema);
-        } else if (schema.anyOf) {
-            resolvedSchema = this.resolveAnyOf(schema);
-        } else if (schema.allOf) {
-            resolvedSchema = this.resolveAllOf(schema);
-        } else if (schema.oneOf) {
-            resolvedSchema = this.resolveOneOf(schema);
-        } else if (schema.not) {
-            resolvedSchema = this.resolveNot(schema);
-        } else if (schema.$ref) {
-            resolvedSchema = this.resolve(this.resolveReference(schema.$ref));
-        } else if (schema.enum) {
-            // If no type is specified, just enum
-            resolvedSchema = this.joi.any().valid(...schema.enum);
-        } else if (typeof schema === 'string') {
+
+        if (typeof schema === 'string') {
             // If schema is itself a string, interpret it as a type
             resolvedSchema = this.resolveType({ type: schema });
+        } else if (schema.$ref) {
+            resolvedSchema = this.resolve(this.resolveReference(schema.$ref));
         } else {
-            //Fall through to whatever.
-            //eslint-disable-next-line no-console
-            console.warn('WARNING: schema missing a \'type\' or \'$ref\' or \'enum\': \n%s', JSON.stringify(schema, null, 2));
-            //TODO: Handle better
-            resolvedSchema = this.joi.any();
+            const partialSchemas = [];
+            if (schema.type) {
+                partialSchemas.push(this.resolveType(schema));
+            } else if (schema.enum) {
+                // If no type is specified, just enum
+                partialSchemas.push(this.joi.any().valid(...schema.enum));
+            }
+            if (schema.anyOf) {
+                partialSchemas.push(this.resolveAnyOf(schema));
+            }
+            if (schema.allOf) {
+                partialSchemas.push(this.resolveAllOf(schema));
+            }
+            if (schema.oneOf) {
+                partialSchemas.push(this.resolveOneOf(schema));
+            }
+            if (schema.not) {
+                partialSchemas.push(this.resolveNot(schema));
+            }
+            if (partialSchemas.length === 0) {
+                //Fall through to whatever.
+                //eslint-disable-next-line no-console
+                console.warn('WARNING: schema missing a \'type\' or \'$ref\' or \'enum\': \n%s', JSON.stringify(schema, null, 2));
+                //TODO: Handle better
+                partialSchemas.push(this.joi.any());
+            }
+            resolvedSchema = partialSchemas.length === 1 ? partialSchemas[0] : this.joi.alternatives(partialSchemas).match('all');
         }
 
         if (this.refineSchema) {
             resolvedSchema = this.refineSchema(resolvedSchema, schema);
         }
 
-        return(resolvedSchema);
+        return resolvedSchema;
     }
 
     resolveReference(value) {
@@ -177,7 +187,7 @@ class SchemaResolver {
     resolveOneOf(schema) {
         Hoek.assert(Util.isArray(schema.oneOf), 'Expected oneOf to be an array.');
 
-        return this.joi.alternatives(schema.oneOf.map(schema => this.resolve(schema))).match('any');
+        return this.joi.alternatives(schema.oneOf.map(schema => this.resolve(schema))).match('one');
     }
 
     resolveAnyOf(schema) {
@@ -189,7 +199,7 @@ class SchemaResolver {
     resolveAllOf(schema) {
         Hoek.assert(Util.isArray(schema.allOf), 'Expected allOf to be an array.');
 
-        return schema.allOf.map(schema => this.resolve(schema)).reduce((a, v) => a.concat(v));
+        return this.joi.alternatives(schema.allOf.map(schema => this.resolve(schema))).match('all');
     }
 
     resolveNot(schema) {
@@ -226,12 +236,10 @@ class SchemaResolver {
 
         let joischema = this.joi.object(resolveproperties(schema));
 
-        if (schema.additionalProperties === true) {
-            joischema = joischema.unknown(true);
-        }
-
         if (Util.isObject(schema.additionalProperties)) {
             joischema = joischema.pattern(/^/, this.resolve(schema.additionalProperties));
+        } else {
+            joischema = joischema.unknown(schema.additionalProperties !== false);
         }
 
         Util.isNumber(schema.minProperties) && (joischema = joischema.min(schema.minProperties));


### PR DESCRIPTION
- build schemas for allOf/anyOf/oneOf and combine with base schema if present. resolves #102
- during allOf handling use `alternatives.match('all')` instead of `concat` 
  - matches against all schemas instead of merging the schemas
  - `.match('all')` matches the behavior of JSONSchema allOf.
- update additionalProperties handling to match JSONSchema spec. resolves #103
- update related tests, add a new test.