### PR TITLE
implement default value handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const optionsSchema = Joi.object({
     refineType: Joi.func().allow(null),
     refineSchema: Joi.func().allow(null),
     strictMode: Joi.boolean().default(false),
+    useDefaults: Joi.boolean(). default(false)
 });
 
 const validate = function (schema, options = {}) {

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -4,12 +4,13 @@ const Hoek = require('@hapi/hoek');
 const Bourne = require('@hapi/bourne');
 
 class SchemaResolver {
-    constructor(root, { subSchemas, refineType, refineSchema, strictMode, extensions = [] }) {
+    constructor(root, { subSchemas, refineType, refineSchema, strictMode, useDefaults, extensions = [] }) {
         this.root = root;
         this.subSchemas = subSchemas;
         this.refineType = refineType;
         this.refineSchema = refineSchema;
         this.strictMode = strictMode;
+        this.useDefaults = useDefaults;
 
         this.joi = Joi.extend(
             {
@@ -77,6 +78,10 @@ class SchemaResolver {
 
         if (this.refineSchema) {
             resolvedSchema = this.refineSchema(resolvedSchema, schema);
+        }
+
+        if (this.useDefaults && schema.default) {
+            resolvedSchema = resolvedSchema.default(schema.default)
         }
 
         return(resolvedSchema);

--- a/test/test-options.js
+++ b/test/test-options.js
@@ -281,4 +281,33 @@ Test('extensions', function (t) {
         t.ok(!schema.validate({x: 'foobar'}).error);
         t.ok(schema.validate({x: 123}).error);
     })
+
+    t.test('useDefaults', function (t) {
+        t.plan(5);
+
+        const schema = Enjoi.schema(
+          {
+              type: 'object',
+              properties: {
+                  x: {
+                      type: 'string',
+                      default: 'foo'
+                  }
+              }
+          },
+          {
+            useDefaults: true
+          }
+        );
+
+        const { value: value0, error: error0 } = schema.validate({x: 'blah'})
+        t.ok(!error0);
+        t.ok(value0.x === 'blah');
+
+        const { value: value1, error: error1 } = schema.validate({})
+        t.ok(!error1);
+        t.ok(value1.x === 'foo');
+
+        t.ok(schema.validate({x: 123}).error);
+    })
 });


### PR DESCRIPTION
Add an option `useDefaults` (named the same as the similar property in AJV) which uses the JSONSchema `default` keyword to populate missing values via `joi.default`. 

This is behind an option since `default` in JSONSchema is an annotation (i.e metadata) and doesn't strictly imply any behavior during validation. The choice to insert defaults in place of missing values is an optional implementation detail provided by some JSONSchema implementations and allowed in the spec.