### PR TITLE
use joi.link to only resolve strictly recursive self-references

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -54,11 +54,11 @@ class SchemaResolver {
         );
     }
 
-    resolve(schema = this.root) {
+    resolve(schema = this.root, ancestors = []) {
         let resolvedSchema;
         let generatedId = this.walkedSchemas.get(schema);
 
-        if (generatedId) {
+        if (generatedId && ancestors.lastIndexOf(generatedId) > -1) {
             // resolve cyclic schema by using joi reference via generated unique ids
             return this.resolveLink(schema)
         } else if (typeof schema === 'object') {
@@ -70,14 +70,14 @@ class SchemaResolver {
             // If schema is itself a string, interpret it as a type
             resolvedSchema = this.resolveType({ type: schema });
         } else if (schema.$ref) {
-            resolvedSchema = this.resolve(this.resolveReference(schema.$ref));
+            resolvedSchema = this.resolve(this.resolveReference(schema.$ref), ancestors.concat(generatedId));
         } else {
             const partialSchemas = [];
             if (schema.type) {
-                partialSchemas.push(this.resolveType(schema));
+                partialSchemas.push(this.resolveType(schema, ancestors.concat(generatedId)));
             } else if (schema.properties) {
                 // if no type is specified, just properties
-                partialSchemas.push(this.object(schema))
+                partialSchemas.push(this.object(schema, ancestors.concat(generatedId)))
             } else if (schema.format) {
                 // if no type is specified, just format
                 partialSchemas.push(this.string(schema))
@@ -86,16 +86,16 @@ class SchemaResolver {
                 partialSchemas.push(this.joi.any().valid(...schema.enum));
             }
             if (schema.anyOf) {
-                partialSchemas.push(this.resolveAnyOf(schema));
+                partialSchemas.push(this.resolveAnyOf(schema, ancestors.concat(generatedId)));
             }
             if (schema.allOf) {
-                partialSchemas.push(this.resolveAllOf(schema));
+                partialSchemas.push(this.resolveAllOf(schema, ancestors.concat(generatedId)));
             }
             if (schema.oneOf) {
-                partialSchemas.push(this.resolveOneOf(schema));
+                partialSchemas.push(this.resolveOneOf(schema, ancestors.concat(generatedId)));
             }
             if (schema.not) {
-                partialSchemas.push(this.resolveNot(schema));
+                partialSchemas.push(this.resolveNot(schema, ancestors.concat(generatedId)));
             }
             if (partialSchemas.length === 0) {
                 //Fall through to whatever.
@@ -116,7 +116,7 @@ class SchemaResolver {
             resolvedSchema = this.refineSchema(resolvedSchema, schema);
         }
 
-        if (this.useDefaults && schema.default) {
+        if (this.useDefaults && schema.default !== undefined) {
             resolvedSchema = resolvedSchema.default(schema.default)
         }
 
@@ -148,7 +148,7 @@ class SchemaResolver {
         return fragment;
     }
 
-    resolveType(schema) {
+    resolveType(schema, ancestors) {
         let joischema;
 
         const typeDefinitionMap = {
@@ -166,7 +166,7 @@ class SchemaResolver {
 
             switch (type) {
                 case 'array':
-                    joischema = this.array(schema);
+                    joischema = this.array(schema, ancestors);
                     break;
                 case 'boolean':
                     joischema = this.joi.boolean();
@@ -176,7 +176,7 @@ class SchemaResolver {
                     joischema = this.number(schema);
                     break;
                 case 'object':
-                    joischema = this.object(schema);
+                    joischema = this.object(schema, ancestors);
                     break;
                 case 'string':
                     joischema = this.string(schema);
@@ -215,31 +215,31 @@ class SchemaResolver {
         return joischema;
     }
 
-    resolveOneOf(schema) {
+    resolveOneOf(schema, ancestors) {
         Hoek.assert(Util.isArray(schema.oneOf), 'Expected oneOf to be an array.');
 
-        return this.joi.alternatives(schema.oneOf.map(schema => this.resolve(schema))).match('one');
+        return this.joi.alternatives(schema.oneOf.map(schema => this.resolve(schema, ancestors))).match('one');
     }
 
-    resolveAnyOf(schema) {
+    resolveAnyOf(schema, ancestors) {
         Hoek.assert(Util.isArray(schema.anyOf), 'Expected anyOf to be an array.');
 
-        return this.joi.alternatives(schema.anyOf.map(schema => this.resolve(schema))).match('any');
+        return this.joi.alternatives(schema.anyOf.map(schema => this.resolve(schema, ancestors))).match('any');
     }
 
-    resolveAllOf(schema) {
+    resolveAllOf(schema, ancestors) {
         Hoek.assert(Util.isArray(schema.allOf), 'Expected allOf to be an array.');
 
-        return this.joi.alternatives(schema.allOf.map(schema => this.resolve(schema))).match('all');
+        return this.joi.alternatives(schema.allOf.map(schema => this.resolve(schema, ancestors))).match('all');
     }
 
-    resolveNot(schema) {
+    resolveNot(schema, ancestors) {
         Hoek.assert(Util.isObject(schema.not), 'Expected Not to be an object.');
 
         return this.joi.alternatives().conditional(
           '.',
           {
-              not: this.resolve(schema.not),
+              not: this.resolve(schema.not, ancestors),
               then: this.joi.any(),
               otherwise: this.joi.any().forbidden()
           }
@@ -250,7 +250,7 @@ class SchemaResolver {
         return this.joi.link().ref(`#${this.walkedSchemas.get(schema)}`)
     }
 
-    object(schema) {
+    object(schema, ancestors) {
 
         const resolveproperties = () => {
             const schemas = {};
@@ -262,7 +262,7 @@ class SchemaResolver {
             Object.keys(schema.properties).forEach((key) => {
                 const property = schema.properties[key];
 
-                let joischema = this.resolve(property);
+                let joischema = this.resolve(property, ancestors);
 
                 if (schema.required && !!~schema.required.indexOf(key)) {
                     joischema = joischema.required();
@@ -277,7 +277,7 @@ class SchemaResolver {
         let joischema = this.joi.object(resolveproperties(schema));
 
         if (Util.isObject(schema.additionalProperties)) {
-            joischema = joischema.pattern(/^/, this.resolve(schema.additionalProperties));
+            joischema = joischema.pattern(/^/, this.resolve(schema.additionalProperties, ancestors));
         } else {
             joischema = joischema.unknown(schema.additionalProperties !== false);
         }
@@ -288,17 +288,17 @@ class SchemaResolver {
         return joischema;
     }
 
-    array(schema) {
+    array(schema, ancestors) {
         let joischema = this.joi.array();
         let items;
 
         const resolveAsArray = (value) => {
             if (Util.isArray(value)) {
                 // found an array, thus its _per type_
-                return value.map((v) => this.resolve(v));
+                return value.map((v) => this.resolve(v, ancestors));
             }
             // it's a single entity, so just resolve it normally
-            return [this.resolve(value)];
+            return [this.resolve(value, ancestors)];
         }
 
         if (schema.items) {

--- a/test/test-types.js
+++ b/test/test-types.js
@@ -576,5 +576,44 @@ Test('types', function (t) {
         }).error, 'error');
     });
 
+    t.test('ref to uncle doesn\'t cause joi error', function (t) {
+        t.plan(1);
+
+        const jsonSchema = {
+            type: "object",
+            properties: {
+                product: {
+                    type: "object",
+                    properties: {
+                        id: {
+                            type: 'integer'
+                        }
+                    }
+                },
+                suggestions: {
+                    type: "array",
+                    items: {
+                        type: "object",
+                        properties: {
+                            product: {
+                                $ref: '#/properties/product'
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        const schema = Enjoi.schema(jsonSchema);
+
+        t.ok(!schema.validate({
+            product: {
+                id: 5
+            },
+            suggestions: [{
+                product: { id: 6 }
+            }]
+        }).error, 'no error');
+    });
+
 });
 


### PR DESCRIPTION
... joi.link fails when attempting to resolve to a cousin or uncle node, which is not a scenario we need to handle since that's scenario is not recursive.