### PR TITLE
Disallow empty string if value is required

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -54,7 +54,7 @@ class SchemaResolver {
         );
     }
 
-    resolve(schema = this.root, ancestors = []) {
+    resolve(schema = this.root, ancestors = [], required = false) {
         let resolvedSchema;
         let generatedId = this.walkedSchemas.get(schema);
 
@@ -68,19 +68,19 @@ class SchemaResolver {
 
         if (typeof schema === 'string') {
             // If schema is itself a string, interpret it as a type
-            resolvedSchema = this.resolveType({ type: schema });
+            resolvedSchema = this.resolveType({ type: schema }, required);
         } else if (schema.$ref) {
             resolvedSchema = this.resolve(this.resolveReference(schema.$ref), ancestors.concat(generatedId));
         } else {
             const partialSchemas = [];
             if (schema.type) {
-                partialSchemas.push(this.resolveType(schema, ancestors.concat(generatedId)));
+                partialSchemas.push(this.resolveType(schema, ancestors.concat(generatedId), required));
             } else if (schema.properties) {
                 // if no type is specified, just properties
                 partialSchemas.push(this.object(schema, ancestors.concat(generatedId)))
             } else if (schema.format) {
                 // if no type is specified, just format
-                partialSchemas.push(this.string(schema))
+                partialSchemas.push(this.string(schema, required))
             } else if (schema.enum) {
                 // If no type is specified, just enum
                 partialSchemas.push(this.joi.any().valid(...schema.enum));
@@ -148,7 +148,7 @@ class SchemaResolver {
         return fragment;
     }
 
-    resolveType(schema, ancestors) {
+    resolveType(schema, ancestors, required) {
         let joischema;
 
         const typeDefinitionMap = {
@@ -157,7 +157,7 @@ class SchemaResolver {
             default: 'default'
         };
 
-        const joitype = (type, format) => {
+        const joitype = (type, format, required) => {
             let joischema;
 
             if (this.refineType) {
@@ -179,7 +179,7 @@ class SchemaResolver {
                     joischema = this.object(schema, ancestors);
                     break;
                 case 'string':
-                    joischema = this.string(schema);
+                    joischema = this.string(schema, required);
                     break;
                 case 'null':
                     joischema = this.joi.any().valid(null);
@@ -197,13 +197,13 @@ class SchemaResolver {
             const schemas = [];
 
             for (let i = 0; i < schema.type.length; i++) {
-                schemas.push(joitype(schema.type[i], schema.format));
+                schemas.push(joitype(schema.type[i], schema.format, required));
             }
 
             joischema = this.joi.alternatives(schemas);
         }
         else {
-            joischema = joitype(schema.type, schema.format);
+            joischema = joitype(schema.type, schema.format, required);
         }
 
         Object.keys(typeDefinitionMap).forEach(function (key) {
@@ -261,10 +261,11 @@ class SchemaResolver {
 
             Object.keys(schema.properties).forEach((key) => {
                 const property = schema.properties[key];
+                const required = schema.required && !!~schema.required.indexOf(key);
 
-                let joischema = this.resolve(property, ancestors);
+                let joischema = this.resolve(property, ancestors, required);
 
-                if (schema.required && !!~schema.required.indexOf(key)) {
+                if (required) {
                     joischema = joischema.required();
                 }
 
@@ -341,7 +342,7 @@ class SchemaResolver {
         return joischema;
     }
 
-    string(schema) {
+    string(schema, required) {
         let joischema = this.joi.string();
 
         const dateRegex = '(\\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])';
@@ -384,20 +385,23 @@ class SchemaResolver {
             case 'guid':
                 return joischema.guid();
         }
-        return this.regularString(schema, joischema);
+        return this.regularString(schema, joischema, required);
     }
 
-    regularString(schema, joischema) {
+    regularString(schema, joischema, required) {
         schema.pattern && (joischema = joischema.regex(new RegExp(schema.pattern)));
 
-        if (Util.isUndefined(schema.minLength)) {
-            schema.minLength = 0;
-            if (!schema.pattern && !schema.format) {
+        if (!required) {
+            if (Util.isUndefined(schema.minLength)) {
+                schema.minLength = 0;
+                if (!schema.pattern && !schema.format) {
+                    joischema = joischema.allow('');
+                }
+            } else if (schema.minLength === 0) {
                 joischema = joischema.allow('');
             }
-        } else if (schema.minLength === 0) {
-            joischema = joischema.allow('');
         }
+
         Util.isNumber(schema.minLength) && (joischema = joischema.min(schema.minLength));
         Util.isNumber(schema.maxLength) && (joischema = joischema.max(schema.maxLength));
         return joischema;

--- a/test/test-types.js
+++ b/test/test-types.js
@@ -449,6 +449,23 @@ Test('types', function (t) {
         t.ok(!schema.validate('').error, 'no error');
     });
 
+    t.test('empty string on a required prop', function (t) {
+        t.plan(2);
+
+        const schema = Enjoi.schema({
+            type: 'object',
+            properties: {
+                foo: {
+                    type: 'string'
+                }
+            },
+            required: ['foo']
+        });
+
+        t.ok(!schema.validate({ foo: 'bar' }).error, 'no error.');
+        t.ok(schema.validate({ foo: '' }).error, 'error.');
+    });
+
     t.test('no type, ref, or enum validates anything.', function (t) {
         t.plan(3);
 


### PR DESCRIPTION
Joi's `allow('')` has been used to combat `string()` not accepting `''`. But that seems to not be taking into account a required object property, for which an empty string as a value should mean empty the same way as an undefined.

Even if it's a matter of preference, there's no meaningful way to describe the criteria. Possibly `"minLength": "x"` would be a workaround.

On the other hand, it is still possible to require a prop but allow `''`, which has already been covered as a unit test which continues to pass.