### PR TITLE
Remove deprecated util methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 const Joi = require('joi');
 const Hoek = require('@hapi/hoek');
-const Util = require('util');
 const SchemaResolver = require('./lib/resolver');
 
 const schemaSchema = Joi.alternatives(Joi.object().unknown(true), Joi.string()).required();
@@ -37,7 +36,7 @@ exports.defaults = function (defaults = {}) {
                 refineSchema: options.refineSchema || defaults.refineSchema,
                 strictMode: options.strictMode || defaults.strictMode
             };
-            if (Util.isArray(options.extensions)) {
+            if (Array.isArray(options.extensions)) {
                 merged.extensions = merged.extensions.concat(options.extensions);
             }
             options = validate(schema, merged);

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -1,6 +1,5 @@
 /* global WeakMap */
 const Joi = require('joi');
-const Util = require('util');
 const Hoek = require('@hapi/hoek');
 const Bourne = require('@hapi/bourne');
 
@@ -193,7 +192,7 @@ class SchemaResolver {
             return joischema.strict(this.strictMode);
         }
 
-        if (Util.isArray(schema.type)) {
+        if (Array.isArray(schema.type)) {
             const schemas = [];
 
             for (let i = 0; i < schema.type.length; i++) {
@@ -216,25 +215,25 @@ class SchemaResolver {
     }
 
     resolveOneOf(schema, ancestors) {
-        Hoek.assert(Util.isArray(schema.oneOf), 'Expected oneOf to be an array.');
+        Hoek.assert(Array.isArray(schema.oneOf), 'Expected oneOf to be an array.');
 
         return this.joi.alternatives(schema.oneOf.map(schema => this.resolve(schema, ancestors))).match('one');
     }
 
     resolveAnyOf(schema, ancestors) {
-        Hoek.assert(Util.isArray(schema.anyOf), 'Expected anyOf to be an array.');
+        Hoek.assert(Array.isArray(schema.anyOf), 'Expected anyOf to be an array.');
 
         return this.joi.alternatives(schema.anyOf.map(schema => this.resolve(schema, ancestors))).match('any');
     }
 
     resolveAllOf(schema, ancestors) {
-        Hoek.assert(Util.isArray(schema.allOf), 'Expected allOf to be an array.');
+        Hoek.assert(Array.isArray(schema.allOf), 'Expected allOf to be an array.');
 
         return this.joi.alternatives(schema.allOf.map(schema => this.resolve(schema, ancestors))).match('all');
     }
 
     resolveNot(schema, ancestors) {
-        Hoek.assert(Util.isObject(schema.not), 'Expected Not to be an object.');
+        Hoek.assert(typeof schema.not === 'object' && schema.not !== null, 'Expected Not to be an object.');
 
         return this.joi.alternatives().conditional(
           '.',
@@ -255,7 +254,7 @@ class SchemaResolver {
         const resolveproperties = () => {
             const schemas = {};
 
-            if (!Util.isObject(schema.properties)) {
+            if (typeof schema.properties !== 'object' || schema.properties === null) {
                 return;
             }
 
@@ -276,14 +275,14 @@ class SchemaResolver {
 
         let joischema = this.joi.object(resolveproperties(schema));
 
-        if (Util.isObject(schema.additionalProperties)) {
+        if (typeof schema.additionalProperties === 'object' && schema.additionalProperties !== null) {
             joischema = joischema.pattern(/^/, this.resolve(schema.additionalProperties, ancestors));
         } else {
             joischema = joischema.unknown(schema.additionalProperties !== false);
         }
 
-        Util.isNumber(schema.minProperties) && (joischema = joischema.min(schema.minProperties));
-        Util.isNumber(schema.maxProperties) && (joischema = joischema.max(schema.maxProperties));
+        typeof schema.minProperties === 'number' && (joischema = joischema.min(schema.minProperties));
+        typeof schema.maxProperties === 'number' && (joischema = joischema.max(schema.maxProperties));
 
         return joischema;
     }
@@ -293,7 +292,7 @@ class SchemaResolver {
         let items;
 
         const resolveAsArray = (value) => {
-            if (Util.isArray(value)) {
+            if (Array.isArray(value)) {
                 // found an array, thus its _per type_
                 return value.map((v) => this.resolve(v, ancestors));
             }
@@ -315,8 +314,8 @@ class SchemaResolver {
             joischema = joischema.max(items.length);
         }
 
-        Util.isNumber(schema.minItems) && (joischema = joischema.min(schema.minItems));
-        Util.isNumber(schema.maxItems) && (joischema = joischema.max(schema.maxItems));
+        typeof schema.minItems === 'number' && (joischema = joischema.min(schema.minItems));
+        typeof schema.maxItems === 'number' && (joischema = joischema.max(schema.maxItems));
 
         if (schema.uniqueItems) {
             joischema = joischema.unique();
@@ -332,11 +331,11 @@ class SchemaResolver {
             joischema = joischema.integer();
         }
 
-        Util.isNumber(schema.minimum) && (joischema = joischema.min(schema.minimum));
-        Util.isNumber(schema.maximum) && (joischema = joischema.max(schema.maximum));
-        Util.isNumber(schema.exclusiveMinimum) && (joischema = joischema.greater(schema.exclusiveMinimum));
-        Util.isNumber(schema.exclusiveMaximum) && (joischema = joischema.less(schema.exclusiveMaximum));
-        Util.isNumber(schema.multipleOf) && schema.multipleOf !== 0 && (joischema = joischema.multiple(schema.multipleOf));
+        typeof schema.minimum === 'number' && (joischema = joischema.min(schema.minimum));
+        typeof schema.maximum === 'number' && (joischema = joischema.max(schema.maximum));
+        typeof schema.exclusiveMinimum === 'number' && (joischema = joischema.greater(schema.exclusiveMinimum));
+        typeof schema.exclusiveMaximum === 'number' && (joischema = joischema.less(schema.exclusiveMaximum));
+        typeof schema.multipleOf === 'number' && schema.multipleOf !== 0 && (joischema = joischema.multiple(schema.multipleOf));
 
         return joischema;
     }
@@ -390,7 +389,7 @@ class SchemaResolver {
     regularString(schema, joischema) {
         schema.pattern && (joischema = joischema.regex(new RegExp(schema.pattern)));
 
-        if (Util.isUndefined(schema.minLength)) {
+        if (schema.minLength === undefined) {
             schema.minLength = 0;
             if (!schema.pattern && !schema.format) {
                 joischema = joischema.allow('');
@@ -398,15 +397,15 @@ class SchemaResolver {
         } else if (schema.minLength === 0) {
             joischema = joischema.allow('');
         }
-        Util.isNumber(schema.minLength) && (joischema = joischema.min(schema.minLength));
-        Util.isNumber(schema.maxLength) && (joischema = joischema.max(schema.maxLength));
+        typeof schema.minLength === 'number' && (joischema = joischema.min(schema.minLength));
+        typeof schema.maxLength === 'number' && (joischema = joischema.max(schema.maxLength));
         return joischema;
     }
 
     binary(schema) {
         let joischema = this.joi.binary();
-        Util.isNumber(schema.minLength) && (joischema = joischema.min(schema.minLength));
-        Util.isNumber(schema.maxLength) && (joischema = joischema.max(schema.maxLength));
+        typeof schema.minLength === 'number' && (joischema = joischema.min(schema.minLength));
+        typeof schema.maxLength === 'number' && (joischema = joischema.max(schema.maxLength));
         return joischema;
     }
 }

--- a/package.json
+++ b/package.json
@@ -54,14 +54,14 @@
   },
   "homepage": "https://github.com/tlivings/enjoi",
   "dependencies": {
-    "@hapi/bourne": "^2.0.0",
-    "@hapi/hoek": "^9.0.3"
+    "@hapi/bourne": "^3.0.0",
+    "@hapi/hoek": "^11.0.6"
   },
   "peerDependencies": {
-    "joi": "^17.1.0"
+    "joi": "^17.13.3"
   },
   "devDependencies": {
-    "joi": "^17.1.0",
+    "joi": "^17.13.3",
     "eslint": "^6.8.0",
     "nyc": "^15.0.0",
     "tape": "^5.0.0"


### PR DESCRIPTION
The `util`-methods used are deprecated by node, and this updates that.


```
(node:28917) [DEP0053] DeprecationWarning: The `util.isObject` API is deprecated. Please use `arg !== null && typeof arg === "object"` instead.
(node:28917) [DEP0052] DeprecationWarning: The `util.isNumber` API is deprecated. Please use `typeof arg === "number"` instead.
(node:28917) [DEP0058] DeprecationWarning: The `util.isUndefined` API is deprecated. Please use `arg === undefined` instead.
(node:28919) [DEP0044] DeprecationWarning: The `util.isArray` API is deprecated. Please use `Array.isArray()` instead.
```